### PR TITLE
Call the Shopify on the Solidus Update / Destroy / Create for a variant

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,11 +1,17 @@
 module Spree
   module ProductDecorator
-    attr_accessor :disable_shopify_sync
+    attr_reader :disable_shopify_sync
 
     def self.prepended(base)
       base.after_create :create_shopify_product, if: :should_export_to_shopify?
       base.after_update :update_shopify_product, if: :should_export_to_shopify?
       base.after_destroy :destroy_shopify_product, if: :should_export_to_shopify?
+    end
+
+    def disable_shopify_sync=(value)
+      return false if value != true
+      master.disable_shopify_sync = true
+      @disable_shopify_sync = true
     end
 
     private

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,7 +1,39 @@
 module Spree
   module VariantDecorator
+    attr_accessor :disable_shopify_sync
+
+    def self.prepended(base)
+      base.after_create :create_shopify_variant, if: :should_export_to_shopify?
+      base.after_update :update_shopify_variant, if: :should_export_to_shopify?
+      base.after_destroy :destroy_shopify_variant, if: :should_export_to_shopify?
+    end
+
     def count_on_hand_for(stock_location)
       stock_items.find_by(stock_location_id: stock_location.id).count_on_hand
+    end
+
+    private
+
+    def create_shopify_variant
+      require 'pry'; binding.pry
+      service = Shopify::VariantUpdater.new(spree_variant_id: id)
+      service.perform
+    end
+
+    def update_shopify_variant
+      service = Shopify::VariantUpdater.new(spree_variant_id: id)
+      service.perform
+    end
+
+    def destroy_shopify_variant
+      return false if pos_variant_id.nil?
+
+      shopify_variant = ShopifyAPI::Variant.find_by_id(pos_variant_id)
+      shopify_variant.present? ? shopify_variant.destroy : false
+    end
+
+    def should_export_to_shopify?
+      disable_shopify_sync != true
     end
   end
 end

--- a/spec/cassettes/A_voided_payment_in_Solidus/refunds_the_Shopify_transaction.yml
+++ b/spec/cassettes/A_voided_payment_in_Solidus/refunds_the_Shopify_transaction.yml
@@ -29,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:45 GMT
+      - Fri, 23 Sep 2016 19:46:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -43,9 +43,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -53,11 +53,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/orders/3796744835
+      - https://glossier-pop-staging.myshopify.com/admin/orders/3797372035
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/21e730b3-8ff6-4e58-a18b-71ba797616e8?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/0f13ae18-c103-4a0a-88a5-34273d746bf9?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
       X-Request-Id:
-      - 21e730b3-8ff6-4e58-a18b-71ba797616e8
+      - 0f13ae18-c103-4a0a-88a5-34273d746bf9
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -71,18 +71,18 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"order":{"id":3796744835,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T14:14:45-04:00","updated_at":"2016-09-23T14:14:45-04:00","number":395,"note":null,"token":"e01969bed6555359eed4e85625cfaf0f","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"paid","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1395","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T14:14:45-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1395,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7009129347,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
+      string: '{"order":{"id":3797372035,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T15:46:37-04:00","updated_at":"2016-09-23T15:46:37-04:00","number":398,"note":null,"token":"b8be9355aa6dc385ae7baac8fa4eeac0","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"paid","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1398","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T15:46:37-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1398,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7010403843,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
         Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
         Smith","country_code":"CA","province_code":"ON"},"shipping_address":{"first_name":"John","address1":"123
         Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
-        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3106990403,"order_id":3796744835,"status":"success","created_at":"2016-09-23T14:14:45-04:00","service":"manual","updated_at":"2016-09-23T14:14:45-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7009129347,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T14:14:45-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3796744835,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1395","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
+        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3107712195,"order_id":3797372035,"status":"success","created_at":"2016-09-23T15:46:37-04:00","service":"manual","updated_at":"2016-09-23T15:46:37-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7010403843,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T15:46:37-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3797372035,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1398","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
         Fake Street","address2":null,"city":"Fakecity","province":"Ontario","country":"Canada","zip":"K2P
         1L4","phone":"555-555-5555","name":"John Smith","province_code":"ON","country_code":"CA","country_name":"Canada","default":true}}}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:45 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:37 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796744835.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797372035.json
     body:
       encoding: US-ASCII
       string: ''
@@ -103,7 +103,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:46 GMT
+      - Fri, 23 Sep 2016 19:46:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -119,9 +119,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -129,9 +129,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/acbe8b4f-b238-4b65-a5ea-ce2b70332cfa?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/af8469ff-fb8f-47c2-8506-b632350f18c4?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
       X-Request-Id:
-      - acbe8b4f-b238-4b65-a5ea-ce2b70332cfa
+      - af8469ff-fb8f-47c2-8506-b632350f18c4
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -145,18 +145,18 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"order":{"id":3796744835,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T14:14:45-04:00","updated_at":"2016-09-23T14:14:45-04:00","number":395,"note":null,"token":"e01969bed6555359eed4e85625cfaf0f","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"paid","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1395","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T14:14:45-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1395,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7009129347,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
-        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":45.4203521,"longitude":-75.69314750000001,"name":"John
+      string: '{"order":{"id":3797372035,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T15:46:37-04:00","updated_at":"2016-09-23T15:46:37-04:00","number":398,"note":null,"token":"b8be9355aa6dc385ae7baac8fa4eeac0","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"paid","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1398","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T15:46:37-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1398,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7010403843,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
+        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
         Smith","country_code":"CA","province_code":"ON"},"shipping_address":{"first_name":"John","address1":"123
-        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":45.4203521,"longitude":-75.69314750000001,"name":"John
-        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3106990403,"order_id":3796744835,"status":"success","created_at":"2016-09-23T14:14:45-04:00","service":"manual","updated_at":"2016-09-23T14:14:45-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7009129347,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T14:14:45-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3796744835,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1395","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
+        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
+        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3107712195,"order_id":3797372035,"status":"success","created_at":"2016-09-23T15:46:37-04:00","service":"manual","updated_at":"2016-09-23T15:46:37-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7010403843,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T15:46:37-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3797372035,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1398","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
         Fake Street","address2":null,"city":"Fakecity","province":"Ontario","country":"Canada","zip":"K2P
         1L4","phone":"555-555-5555","name":"John Smith","province_code":"ON","country_code":"CA","country_name":"Canada","default":true}}}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:46 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:38 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796744835/transactions.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797372035/transactions.json
     body:
       encoding: US-ASCII
       string: ''
@@ -177,7 +177,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:46 GMT
+      - Fri, 23 Sep 2016 19:46:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -193,9 +193,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -203,9 +203,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e90d8f5b-8fbf-41d8-8aa7-4883497f91a8?source%5Baction%5D=index&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/56ec9e49-1a30-4fd9-9e0d-cd8007eac886?source%5Baction%5D=index&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin
       X-Request-Id:
-      - e90d8f5b-8fbf-41d8-8aa7-4883497f91a8
+      - 56ec9e49-1a30-4fd9-9e0d-cd8007eac886
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -219,12 +219,12 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"transactions":[{"id":4145776899,"order_id":3796744835,"amount":"100.00","kind":"capture","gateway":"","status":"success","message":null,"created_at":"2016-09-23T14:14:45-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":null,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}]}'
+      string: '{"transactions":[{"id":4146558723,"order_id":3797372035,"amount":"100.00","kind":"capture","gateway":"","status":"success","message":null,"created_at":"2016-09-23T15:46:37-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":null,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}]}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:46 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:38 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796744835/transactions/4145776899.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797372035/transactions/4146558723.json
     body:
       encoding: US-ASCII
       string: ''
@@ -245,7 +245,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:46 GMT
+      - Fri, 23 Sep 2016 19:46:38 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -261,9 +261,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -271,9 +271,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/f4df59c4-4653-4839-9862-583da920a18c?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/c519fa59-f40c-4e16-8c92-eadbab2c2496?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin
       X-Request-Id:
-      - f4df59c4-4653-4839-9862-583da920a18c
+      - c519fa59-f40c-4e16-8c92-eadbab2c2496
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -287,15 +287,15 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"transaction":{"id":4145776899,"order_id":3796744835,"amount":"100.00","kind":"capture","gateway":"","status":"success","message":null,"created_at":"2016-09-23T14:14:45-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":null,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}}'
+      string: '{"transaction":{"id":4146558723,"order_id":3797372035,"amount":"100.00","kind":"capture","gateway":"","status":"success","message":null,"created_at":"2016-09-23T15:46:37-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":null,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:46 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:38 GMT
 - request:
     method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796744835/refunds.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797372035/refunds.json
     body:
       encoding: UTF-8
-      string: '{"refund":{"shipping":{"amount":0},"note":null,"notify":false,"restock":false,"transactions":[{"parent_id":4145776899,"amount":"1.0","gateway":"shopify-payments","kind":"refund"}]}}'
+      string: '{"refund":{"shipping":{"amount":0},"note":null,"notify":false,"restock":false,"transactions":[{"parent_id":4146558723,"amount":"1.0","gateway":"shopify-payments","kind":"refund"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -315,7 +315,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:47 GMT
+      - Fri, 23 Sep 2016 19:46:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -329,9 +329,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -339,11 +339,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/orders/3796744835/refunds/142908099
+      - https://glossier-pop-staging.myshopify.com/admin/orders/3797372035/refunds/142945987
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c5e33ad9-d9ed-4be1-91d6-c89be6e2bda2?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Frefunds&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/6cfc35c7-8b69-47d4-9d4a-16d8e7ad8712?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Frefunds&source%5Bsection%5D=admin
       X-Request-Id:
-      - c5e33ad9-d9ed-4be1-91d6-c89be6e2bda2
+      - 6cfc35c7-8b69-47d4-9d4a-16d8e7ad8712
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -357,14 +357,14 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"refund":{"id":142908099,"order_id":3796744835,"created_at":"2016-09-23T14:14:46-04:00","note":null,"restock":false,"user_id":0,"refund_line_items":[],"transactions":[{"id":4145777155,"order_id":3796744835,"amount":"1.00","kind":"refund","gateway":"","status":"success","message":"Refunded
-        1.00 from manual gateway","created_at":"2016-09-23T14:14:47-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":4145776899,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}],"order_adjustments":[{"id":103550147,"order_id":3796744835,"refund_id":142908099,"amount":"-1.00","tax_amount":"0.00","kind":"refund_discrepancy","reason":"Refund
+      string: '{"refund":{"id":142945987,"order_id":3797372035,"created_at":"2016-09-23T15:46:38-04:00","note":null,"restock":false,"user_id":0,"refund_line_items":[],"transactions":[{"id":4146559235,"order_id":3797372035,"amount":"1.00","kind":"refund","gateway":"","status":"success","message":"Refunded
+        1.00 from manual gateway","created_at":"2016-09-23T15:46:39-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":4146558723,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}],"order_adjustments":[{"id":103566147,"order_id":3797372035,"refund_id":142945987,"amount":"-1.00","tax_amount":"0.00","kind":"refund_discrepancy","reason":"Refund
         discrepancy"}]}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:47 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:39 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796744835.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797372035.json
     body:
       encoding: US-ASCII
       string: ''
@@ -385,7 +385,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:47 GMT
+      - Fri, 23 Sep 2016 19:46:39 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -401,9 +401,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -411,9 +411,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/7ec5b98e-bbec-46ca-9cd4-57a73d1c28d9?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/f24d7865-4e92-4a10-9e14-8eea7346e3b2?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
       X-Request-Id:
-      - 7ec5b98e-bbec-46ca-9cd4-57a73d1c28d9
+      - f24d7865-4e92-4a10-9e14-8eea7346e3b2
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -427,20 +427,20 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"order":{"id":3796744835,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T14:14:45-04:00","updated_at":"2016-09-23T14:14:47-04:00","number":395,"note":null,"token":"e01969bed6555359eed4e85625cfaf0f","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"partially_refunded","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1395","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T14:14:45-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1395,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7009129347,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
+      string: '{"order":{"id":3797372035,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T15:46:37-04:00","updated_at":"2016-09-23T15:46:39-04:00","number":398,"note":null,"token":"b8be9355aa6dc385ae7baac8fa4eeac0","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"partially_refunded","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1398","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T15:46:37-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1398,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7010403843,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
         Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":45.4203521,"longitude":-75.69314750000001,"name":"John
         Smith","country_code":"CA","province_code":"ON"},"shipping_address":{"first_name":"John","address1":"123
         Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":45.4203521,"longitude":-75.69314750000001,"name":"John
-        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3106990403,"order_id":3796744835,"status":"success","created_at":"2016-09-23T14:14:45-04:00","service":"manual","updated_at":"2016-09-23T14:14:45-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7009129347,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[{"id":142908099,"order_id":3796744835,"created_at":"2016-09-23T14:14:46-04:00","note":null,"restock":false,"user_id":0,"refund_line_items":[],"transactions":[{"id":4145777155,"order_id":3796744835,"amount":"1.00","kind":"refund","gateway":"","status":"success","message":"Refunded
-        1.00 from manual gateway","created_at":"2016-09-23T14:14:47-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":4145776899,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}],"order_adjustments":[{"id":103550147,"order_id":3796744835,"refund_id":142908099,"amount":"-1.00","tax_amount":"0.00","kind":"refund_discrepancy","reason":"Refund
-        discrepancy"}]}],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T14:14:47-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"399.00","last_order_id":3796744835,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1395","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
+        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3107712195,"order_id":3797372035,"status":"success","created_at":"2016-09-23T15:46:37-04:00","service":"manual","updated_at":"2016-09-23T15:46:37-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7010403843,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[{"id":142945987,"order_id":3797372035,"created_at":"2016-09-23T15:46:38-04:00","note":null,"restock":false,"user_id":0,"refund_line_items":[],"transactions":[{"id":4146559235,"order_id":3797372035,"amount":"1.00","kind":"refund","gateway":"","status":"success","message":"Refunded
+        1.00 from manual gateway","created_at":"2016-09-23T15:46:39-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":4146558723,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}],"order_adjustments":[{"id":103566147,"order_id":3797372035,"refund_id":142945987,"amount":"-1.00","tax_amount":"0.00","kind":"refund_discrepancy","reason":"Refund
+        discrepancy"}]}],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T15:46:39-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"399.00","last_order_id":3797372035,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1398","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
         Fake Street","address2":null,"city":"Fakecity","province":"Ontario","country":"Canada","zip":"K2P
         1L4","phone":"555-555-5555","name":"John Smith","province_code":"ON","country_code":"CA","country_name":"Canada","default":true}}}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:47 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:39 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796744835.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797372035.json
     body:
       encoding: US-ASCII
       string: ''
@@ -461,7 +461,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:47 GMT
+      - Fri, 23 Sep 2016 19:46:40 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -477,9 +477,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -489,9 +489,9 @@ http_interactions:
       Location:
       - "/admin/orders"
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/479ca2b3-aa41-4955-8fad-c187a7cd9c8c?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/722708bd-34f3-4343-99d9-997ced9b57df?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
       X-Request-Id:
-      - 479ca2b3-aa41-4955-8fad-c187a7cd9c8c
+      - 722708bd-34f3-4343-99d9-997ced9b57df
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -507,5 +507,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:47 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Export_a_Spree_product_with_its_variants_on_Shopify/creates_a_product_with_the_associated_variant.yml
+++ b/spec/cassettes/Export_a_Spree_product_with_its_variants_on_Shopify/creates_a_product_with_the_associated_variant.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:48 GMT
+      - Fri, 23 Sep 2016 19:47:28 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 17/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 17/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/6379843f-6ce6-40c9-a438-ccdc86712bd0?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/01594ff7-49ca-4c6a-8acf-bdbb034f77f3?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 6379843f-6ce6-40c9-a438-ccdc86712bd0
+      - 01594ff7-49ca-4c6a-8acf-bdbb034f77f3
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:48 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:28 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:48.062Z","updated_at":"2016-09-23T18:14:48.293Z","published_at":"2015-09-23T18:14:47.969Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"master-sku","inventory_management":"shopify","updated_at":"2016-09-23T18:14:48.287Z","option1":"master-sku"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"slave-sku","inventory_management":"shopify","updated_at":"2016-09-23T18:14:48.267Z","option1":"slave-sku"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:47:28.334Z","updated_at":"2016-09-23T19:47:28.417Z","published_at":"2015-09-23T19:47:28.301Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"master-sku","inventory_management":"shopify","updated_at":"2016-09-23T19:47:28.415Z","option1":"master-sku"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"slave-sku","inventory_management":"shopify","updated_at":"2016-09-23T19:47:28.403Z","option1":"slave-sku"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:49 GMT
+      - Fri, 23 Sep 2016 19:47:29 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 17/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 17/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590657027
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591925635
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/a605e27c-b5a2-4760-91b3-fc3ec991300d?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b3ba3778-bacf-420e-b4a1-ee88fa459238?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - a605e27c-b5a2-4760-91b3-fc3ec991300d
+      - b3ba3778-bacf-420e-b4a1-ee88fa459238
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590657027,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:48-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:48-04:00","published_at":"2015-09-23T14:14:47-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631149699,"product_id":8590657027,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631149763,"product_id":8590657027,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314160515,"product_id":8590657027,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591925635,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:28-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:29-04:00","published_at":"2015-09-23T15:47:28-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634466179,"product_id":8591925635,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634466243,"product_id":8591925635,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315865987,"product_id":8591925635,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:49 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:29 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590657027.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591925635.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:49 GMT
+      - Fri, 23 Sep 2016 19:47:29 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +177,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 17/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 17/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +187,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/8873e97c-8e7e-4f22-b950-2049f1e9a873?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b46d823e-9e51-4524-87b0-b033fd2002aa?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 8873e97c-8e7e-4f22-b950-2049f1e9a873
+      - b46d823e-9e51-4524-87b0-b033fd2002aa
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +203,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590657027,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:48-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:48-04:00","published_at":"2015-09-23T14:14:47-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631149699,"product_id":8590657027,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631149763,"product_id":8590657027,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314160515,"product_id":8590657027,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591925635,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:28-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:29-04:00","published_at":"2015-09-23T15:47:28-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634466179,"product_id":8591925635,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634466243,"product_id":8591925635,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315865987,"product_id":8591925635,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:49 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:29 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590657027.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591925635.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590657027,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:48.062Z","handle":"product-name","updated_at":"2016-09-23T18:14:48.293Z","published_at":"2015-09-23T18:14:47.969Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631149699,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631149763,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314160515,"product_id":8590657027,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[{"variant_ids":["28631149699"],"attachment":null},{"variant_ids":["28631149763"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591925635,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:47:28.334Z","handle":"product-name","updated_at":"2016-09-23T19:47:28.417Z","published_at":"2015-09-23T19:47:28.301Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634466179,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634466243,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315865987,"product_id":8591925635,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[{"variant_ids":["28634466179"],"attachment":null},{"variant_ids":["28634466243"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +233,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:49 GMT
+      - Fri, 23 Sep 2016 19:47:30 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +249,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 17/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 17/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +259,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590657027
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591925635
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/77d22a0a-52c5-401e-ac8f-63e88732d72a?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/53bf78d0-273d-4296-99a5-c457c86051ba?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 77d22a0a-52c5-401e-ac8f-63e88732d72a
+      - 53bf78d0-273d-4296-99a5-c457c86051ba
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +277,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590657027,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:48-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:49-04:00","published_at":"2015-09-23T14:14:47-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631149699,"product_id":8590657027,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631149763,"product_id":8590657027,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314160515,"product_id":8590657027,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591925635,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:28-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:30-04:00","published_at":"2015-09-23T15:47:28-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634466179,"product_id":8591925635,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634466243,"product_id":8591925635,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315865987,"product_id":8591925635,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:49 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:30 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590657027.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591925635.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,7 +304,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:50 GMT
+      - Fri, 23 Sep 2016 19:47:31 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -320,9 +320,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 16/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 16/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -330,9 +330,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1957e827-9fca-4524-8ffc-5ee8065f2fef?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/c8954e53-e9d3-4655-bc4a-340a230d70e5?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 1957e827-9fca-4524-8ffc-5ee8065f2fef
+      - c8954e53-e9d3-4655-bc4a-340a230d70e5
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -346,13 +346,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590657027,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:48-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:49-04:00","published_at":"2015-09-23T14:14:47-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631149699,"product_id":8590657027,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631149763,"product_id":8590657027,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:48-04:00","updated_at":"2016-09-23T14:14:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314160515,"product_id":8590657027,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591925635,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:28-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:30-04:00","published_at":"2015-09-23T15:47:28-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634466179,"product_id":8591925635,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634466243,"product_id":8591925635,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:29-04:00","updated_at":"2016-09-23T15:47:29-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315865987,"product_id":8591925635,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:50 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:31 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590657027.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591925635.json
     body:
       encoding: US-ASCII
       string: ''
@@ -373,7 +373,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:50 GMT
+      - Fri, 23 Sep 2016 19:47:31 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -389,9 +389,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 17/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 17/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -401,9 +401,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ae83bce9-8459-4ea5-9192-4dad392962cd?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/284ad9c0-c317-4eca-b8ce-132f16b5cc2f?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - ae83bce9-8459-4ea5-9192-4dad392962cd
+      - 284ad9c0-c317-4eca-b8ce-132f16b5cc2f
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -419,5 +419,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:50 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Export_a_Spree_product_with_its_variants_on_Shopify/with_a_master_variant_containe_one_image/creates_a_product_with_the_associated_variant_images.yml
+++ b/spec/cassettes/Export_a_Spree_product_with_its_variants_on_Shopify/with_a_master_variant_containe_one_image/creates_a_product_with_the_associated_variant_images.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:51 GMT
+      - Fri, 23 Sep 2016 19:47:33 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 13/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 13/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/225b7901-2224-4ff9-ad05-bcad308c04f4?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8b656b3c-86af-47c5-be0d-ce255fd9671c?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 225b7901-2224-4ff9-ad05-bcad308c04f4
+      - 8b656b3c-86af-47c5-be0d-ce255fd9671c
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:51 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:33 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:50.604Z","updated_at":"2016-09-23T18:14:50.773Z","published_at":"2015-09-23T18:14:50.543Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"master-sku","inventory_management":"shopify","updated_at":"2016-09-23T18:14:51.367Z","option1":"master-sku"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"slave-sku","inventory_management":"shopify","updated_at":"2016-09-23T18:14:50.744Z","option1":"slave-sku"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:47:31.898Z","updated_at":"2016-09-23T19:47:31.977Z","published_at":"2015-09-23T19:47:31.872Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"master-sku","inventory_management":"shopify","updated_at":"2016-09-23T19:47:32.302Z","option1":"master-sku"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"slave-sku","inventory_management":"shopify","updated_at":"2016-09-23T19:47:31.964Z","option1":"slave-sku"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:52 GMT
+      - Fri, 23 Sep 2016 19:47:34 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 14/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 14/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590657987
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591926403
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/dca16f48-fc0a-4a5b-8b4d-4f77969a2b17?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/e533719f-a5da-45cc-823b-5624084e76b6?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - dca16f48-fc0a-4a5b-8b4d-4f77969a2b17
+      - e533719f-a5da-45cc-823b-5624084e76b6
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590657987,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:51-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:51-04:00","published_at":"2015-09-23T14:14:50-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631151491,"product_id":8590657987,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:51-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631151555,"product_id":8590657987,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:51-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314161603,"product_id":8590657987,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591926403,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:33-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:33-04:00","published_at":"2015-09-23T15:47:31-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634467331,"product_id":8591926403,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:33-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634467395,"product_id":8591926403,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:33-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315866755,"product_id":8591926403,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:52 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:34 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590657987.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591926403.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:52 GMT
+      - Fri, 23 Sep 2016 19:47:34 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +177,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 13/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 13/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +187,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/fe3d1a8c-43e0-4bb5-99e1-690afd3a4076?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/04bb0226-a7dc-402f-9e53-ba35b46f24da?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - fe3d1a8c-43e0-4bb5-99e1-690afd3a4076
+      - 04bb0226-a7dc-402f-9e53-ba35b46f24da
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +203,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590657987,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:51-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:51-04:00","published_at":"2015-09-23T14:14:50-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631151491,"product_id":8590657987,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:51-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631151555,"product_id":8590657987,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:51-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314161603,"product_id":8590657987,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591926403,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:33-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:33-04:00","published_at":"2015-09-23T15:47:31-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634467331,"product_id":8591926403,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:33-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634467395,"product_id":8591926403,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:33-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315866755,"product_id":8591926403,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:52 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:34 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590657987.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591926403.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590657987,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:50.604Z","handle":"product-name","updated_at":"2016-09-23T18:14:51.370Z","published_at":"2015-09-23T18:14:50.543Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631151491,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:51-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631151555,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:51-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314161603,"product_id":8590657987,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[{"variant_ids":["28631151491"],"attachment":"/9j/4AAQSkZJRgABAQEAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsL\nDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/\n2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIy\nMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCADwAPADASIAAhEBAxEB/8QA\nGwAAAQUBAQAAAAAAAAAAAAAAAQADBAUGAgf/xAA4EAABBAEDAgUCBQIFBAMA\nAAABAAIDEQQSITEFQRMiUWFxBoEUMpGhsSNCJDNSYtEVQ3LhFpLB/8QAGQEA\nAwEBAQAAAAAAAAAAAAAAAAECAwQF/8QAJxEBAQACAgIDAAEDBQAAAAAAAAEC\nEQMxEiEEIkEFExQyMzRCUWH/2gAMAwEAAhEDEQA/APBQgkjSkySSSQCSSSQC\nSR7IUgEkkkmCSSSQC7olDuiUHHPflPxf5jfkJnunmVrb8hKqx7X1XN9k4Bsu\nP+6PhOjhcz2cQQXSF1uSkroECE06Ymy1pr1TwOpo+FWrE45zK6iNmD+g/wCF\nRq+yh/Sd8FUJ2K04+nn/AC59oVWgiktHICSKVIAhJLskOUGaRSSQkkkkQgFS\nNIsFupWWJ0uXLOwof6kHJtVpK+d9OTNB84Krcnp82M8te0ihyjcO42IfCB5K\nKSEgkkkmCH5kSh3XXZI45KdZWofKZPKeZ+YIp49tFX9ZvwnANlx/3G3/AKU5\nWy5a93CAUyTrJv8AKP3Xcr6FdymWnaleOLn5+TX1jpx232Tkf5RXCYduno92\nKs56Y/Hy++jeSP6R+FnytDOP6ZWfdynx9J+XPcBIDdJIclaOIaS4QBRQCSRK\nFIOG0kkkIJFLukgHYGl0rQPVbzFhbDFGwCqAHysX0tnidSx29i8Wt1FZeRxv\nwoyaY9HvABF7qLk40coEcjd991aMYSAmpodr7qFS1guqdMdiyF7N2EqqK3mV\nEHAh7bB5CyXUMA48hc3eM8FXjU54fsV6P3SSVsw7ro8Id0Sg3KdZ+YJop6Me\nZvyiqx7aQ/5jP/FdPIY2zwEjQljH+1Q82cF3hNPG5XLJuvcyymGNpuSUvf6W\nugaUVm5JJrsnRJRq10SaeXnlbd1IB2qk9DelQvFt2xU3HFx2fVRydNfi++QJ\nh5Fnn/mI91o5R5FnZNnu+Sji6V86a04SSSWrzySSSQBtJBHdAN0inNIKWkIF\nhtJdFnulpKC0s+gM19Vj9gXfstdjup+53tZP6fOjrEN1uCP2Wie8wzgAkUe4\nUXtphPq0cVFt8Lp+7a5UDHy26PhP/iWnuFne1eO0PMirzAX6hUWYGO1NcLY4\nGlo5aeDZ/RUWbE1tgOs0TR4ITxqrNRl8zE8E62bsvb2URWuVK5wO3HZQtOqQ\nBtBpWsY2So4abSsWnnt8tHnhMmqFplZoTQvuumvDSCg5pb90vDJtAm5fSdJ1\nCR0uvjak06Vz9ybJ3JTRprKI9ly2xQSkjW8mV7qQ15BF37J5rwO1lR9Qc3jd\nAFw9ggbS2uF8UrTHH9AFUQebrsr3E3xWb8LLlv1dnwvfI6kHkKzcwqZ/yVpp\nB5Cs3kip5PXUUuFX8hOjSSI+UqW7zNBSHCKRQAKCKCA61BGx6prUUtXwgbPJ\ncpnUAeEQ73KB5J/T5RDnwPJoB4v4Wq6gwtcXN7GliWvN7FbKSfxsCCY7lzAT\n8hRl20wu5o1Fl6e6lRZxjcCD+qo3SUbauTlkHuizat6a8Znis3Y5wrluyos9\n4L9TDwVDi6lIGOYJHN+E7jNdkt8w3/lKY6Py3NK+WIvds01fmUV/ltjRxurK\ncuieRHd8Ha1AcHaiQ6tu6raLDRZr8wFAKPJGXmwFN8J4bbeRz8JxsJa0yNGx\nANnsU0+O0NrA86XD8oBsJwQ6Qd7b2Uotj0P8wt0dWPlNeHK0s0+Yc0PlCpoz\nI3XEQRu3e/ZKZgYxgregpscIewSfmAbRPqFxmRa3Y7wPLpHCFVELC0C+Ua2r\nkrrKjdE9p/t4CLCCwvo2gfugjc1jtxZ/hW/S7LZWni7CpRbjYV30m9BsLPl9\n4un4l1yRLkB0H4WZywBlSgeq1UrfKsvnNrLk+VHD26f5GfWVGCKQ7pLoeSCB\nRPwueUJIoI90OEycUUaSRtIgS4RsIoANO61PTcuN3TxjzeUEWx3oeKWYCvun\n4pd08uqy06hv27pZaXx9pGVhiCIAm3OFilSynS8ha3Mx25PT4J4zbg2qP8LJ\n5cZa8u3q6NpY3bTP0exWvc9rg2x7NtWreoMiY6Ix06ua2/8ASr8NwfCSNiD2\n7rid8jjRtx7Eos2JdT0fdLPKHHU4UNwRuQmRHqvm6v5T8UkjW89uD3XLpXOe\nNArVz7JQ0drbDpHFttG4urH/ACpEbg5ukuDoq033A7KJI2R0hB2DdrJVh0ot\njdofjGRvc82E6W/elf4EkR8M8h37HutC3p5GM1zIySQQSPfYKc7oP4vHZNiH\nWBsQdyAtFidJfH0qDWPPd1XdZ5ZxeGHbFYPTZWB8Gh2g9/QnevsFLyelh7Ym\nxjaN2xHB9QtdHgNJma1vB5+VXBgjkc3bk8o8lY4emXyentlY9l24cKvgww3E\ndJIKHYeq0cLAMqQUNIJCreq5WNiObHe4/tbynL70rPHU8qoND3g7FoHaladH\nNamuO/ZQ4c+KSXS6LTqPJO67e0xT64ztdmuyectmi4M5hnMl9I3Y/Cy3URWa\n/wCy0uPO3IivvXZZ3qorOd8BZcU1dO/5+Uz45lEHujVpIF4HK6XkFp3XJaUd\nTT3XVjsUFqVxpKWknsu0kbHiYRpFBDMkrSKXZAILXdELX4jdJuuQsiFpvpid\njXujfXqpz6acd+zR42KTFLj6gIn+Zgdy09wsp1TGdBMWPG/r6rYztLWNc00A\nbBVF1Joysi+wWeGVa5TfpQ4gcy+QD7Wniwudq/RThjOLg0NDbTn4Pweavvau\n5FIrSHVR/KeycghLstrCQAeSXJzLaI30ZAW+yOPNBFKHOeDR2CL0c1FmIo44\nnSPOnSdia3IUOXq8LW6GRsc4G7r+K4RlLuqSvji/yYW65KIHfZLKj/C4Qkbp\nazYUAp3+VVls3Olx9PfUkMWS1rhQdTXb2LW9dPE+Fvhu8tbey8fng8TH8dtM\nlbvY7rYfT/VxldNbG6T+owUbWeeH/KDC3eq1uPpDXtrb2/lZjqEsTMtwY4Hz\ndirhk+mNztW/ZY/qryc1waCC7j3IKMZttLMTxI/EvLeDusxOwT5+VK476iBf\nsr3HyPFa15NmqKp2Runz5MZgBkfIaBNWrx2rm/xlR8aNmXENwHXQPoVBkdOW\nF97XRr1VlK0dNEjHAeI15sHcX6KPgxmTHmc7gnv3Wktc1kup+pPQJCTK0k2A\no3WBWd8tCselwBhc++VA6yP8YNv7VnP9R05b/tZL/wBqxcvBNLv1Qd2WzgvR\nqkqXe/ol8oRpzv2KQc4d10QENPqgAglSRTIkAkN+V0PQIBAKVhZLsXIbI0A0\neCo6I5SEej487snAa9+kEjsVAljsE0SoP03mO0ugcTp7bq8nayIa7sfFhYWe\nNdMy2q8eKSSfW8EtHqd1H6nmeA90Qdqv7qXkdQgijdpf5yPRU2Piu6hlDU6t\nR5A7K5P2ouV/ECR0kzq7FS8XAHiMdYc0nelr8L6dZE2zGdNbl1KJl9OZh69B\nDm8hl/wn5zqDHH3uqCdjsDN1EHQ/0V1L02XP6doFU4WDfCbEmJkxCDKoEbai\nE03A6hjN/wAFmaoju0alOt3dXcvWp0Yy9EGPo21NbSr8DJlxpmvaa3sqb/0u\naaUfiZRzuAbVzB02ARsZ4Y0jun6nYmNyu4tMPJZN07xA/nt791nuryF0oc07\ng8qxkkZjTCGGgOXADZVmX55Cd69FE9V0W7mqgQTOimc0uOlxv7pl8LpM951m\nN4Ntc3kJ6QNHZPwxtyWA2BIzv7KtqmHlPFWy4LnzF2Rk6rNknclOyytDGQY4\nOgd+CSrQYDZHBdnogDw5rhq9+E/KMc+Lx6c4OPIyDWePW1T9aH+Kaf8AatWI\n2wwjHB1O5NLPdZxXGZrnuZGKP53V+yiXeba/7fSi7oO4UjRjs/NK5x9GtXLp\nIgBpY752W7hqOBfwj5R7oucw/wBjr9S5cITSSRQQlwkkEUEQ3R7oUimBRCCI\nQFl0mV8WWwsAO+69C8BuZhB2oWRRG5XmeNJokaaujwvVPph7svBDXNawAeUB\nRnNtMazM/Q/Fmpztx6FXXS+jHHY0jU0nsapX8/SwBqBNjuGp7EjkfTG7uHdY\nZ5Za01xkdY8A8KizcCrAVTmfTf4p73tkLDzRNH9FpY4zDvKdR/RVGd1qKLKE\nbxwdqG5UY5Xfo7pkczoc2OakiMwHcbFNR9HBc0gu83DR2Wyiy8nKf5cV7/S2\nmle9H+np82XxHYQEZ5JFLaW3tH1jFYn0s3wxLbjfqEZ8X8OKLHUB6L1yX6dG\nJiERRhorhYTrOJMJy1gc7f8At2Rk34eTd0w2TiumkLyCL+yhz47mOAIra7K1\nUmLO8f5I23Vf1LpEmRACAY3t43SxrXkxmtxjsiRrXkCz8LrByHR5QAFtfsU+\n+GduUYZo2Na0XsKUjp+AXzeIG+UcGuVpdMMblck6KOzwb9lfx4onxGgbOrfZ\nRIYHNrgC1YPmONDTNJPusd6dHJ9/SozIX450MJ99KyvWMaZ8zXBnY2SQP5Wk\nyZnSuLpKPyXKh6q3Hc5lsYedxJX8owu8mvLj48GlI7HeOSz/AO4/5XLoJC3Y\nA/Dgf/1SXwxVqDJAPUCx+xTBijdektNerq/kLpeXTDopWbmNwHwuO6dLJGbt\nbIB/tN/wgZnH81u/8qQg2Er3R1NP9lfBQNX5UBykpbomHt+i4OP/AKT+qNn/\nAE6YRCcOO8cUfuuSxzeQQhNxscopAE8BdaHD+0/onstEw0Rutn9LdU/D5DGl\n8rvvsFjQrPpeWcadpofYbopyveMQty4GucBZHracPTA939PUB6NNLPfTfVTN\nC3y2e9ra4socATysrJaq2wzH0bxgA/avdH/4lhySanNP2VxE4ADupcb2pzGQ\nrlUfA6JDiNHhxtA/VXkLjjsA8u3CgCQE3ZAXfitG4P8AynrSe06aczREObQ7\n2sn1PpxlaQ1wYw78cq4lmkO4NtPA9U1LK1wp35jyp7XhfGsPN0Zhc4OLux29\nlElwY42HZ5B83m7LX5b4gDZ79lj/AKjz3Q4Uromm+G+5KWm8ztZjqGPDNMQ2\nMEjuoJM+O0Na2mjgeivek9NfHinIy3apHbn2UfLjmeTpjAaosu3Vjy4ydKln\nUnMcNTQTaGTmeM3VuLXcuC8eYtF+i5MVN0ub7JWLxywt3pAdITdUfhU/VZLD\nbNi+4Dh/yrXIYWPO1eipepuvSXA7HkcowntfyMpeP0ry1t6tFCvzROXDnFw2\neJPZ4ooEkHU03+xC5L2u/M2j6hdLya4OkH+5jki94Hmpw990nGhVhzfdCu7S\nfhCA8h7Fp9twgW1xRHsgkmEu9kgd+VyEbSbbd37o88rgFEFI9um0OAuw5NjZ\ndAoPbstY/kD5UzAxWSShpaT6EHdQ27lX/Q4nyzAFo08oLUrRYDJo2tbC/SeO\nVrenZ7oGtEry4j0KoomiMAXSktnjZySo3r2q47mm3xepCQbHZWUeU099l5/B\nlAkeG/8AVW0Ga+Mc6iU5kxywsbQZDQLJSGQzuRZ/ZZVvUpHu0/lAXbuoPHe0\n9osaf8Q072PYJh04L3H7Kh/6k9osmz6Jl3UzZsqRpdSPjOxo7rPdcxWTtZsK\na7UB6pubqxB2PCaxc4ZMhbIbo7IaYf8Aqvx2ZEszWG/CB4U3IwTVtaKVjBjt\njcQNwO6bz85mPHejVXZTI25M936xQzwtY3zAWq98LHva2rr07qRkZE+W4/0S\nweqjxsMbt9/ZFhy2dqrqEDRq0squKWP6qDQu+e62ua3zE6Csf1YDegQNXBFI\nnbTK746pTtRB4QJv5Rd7JaHHstnGaKFJ3wXXvQR8H/chPjTPZJPeCP8AVsuh\nGwchB+NFFcrpCiXQXKIQe3QRagEQgbOxjcb191rPppoMm7ST2I4/lZWFgc8A\nlbn6dxmMpwaDtzVINfOhadzt7FDQ1uzW38BPuY090C0N7H5JWdipXDQQeKTr\nZgzYWT7Jh0riaBtc3p3qykd9p7Z5KskNb7LuPILjfDRwqwOLned23opAlFbH\nhG0XFOdLe1qNNLzvsmTKDvaaklBFo2nTiR5s0U502QDNaHbA+6iOeHBcwyeH\nMHdwUK01E2U+tEX5k3iY8mRK50xsji0caNzsmB5Nhza+6vocXwwXUBfKNbpz\nPGYa/VDPi6dg21XSYm3Hm5WtmhHYKryo2RMc4jelWkzJjMppDjvaxnWnPE5a\n7QWHjZbjLB1F1crH9dawvJDaI590Y9tMr9VAdN7bLklA7FK1bOUEr3QtBA2K\nCCSBse6KCKCJdBBEIAjddBALpqAk4rC6QBos/Fr0HoELmY4c5h+apYXA0iRu\n+/YL0npcZ/BMJcb9LQaw0eW1wWNPN/CkMZ5aNpeEPVRYNoT46Gxr4Ud7fW1a\n+AOzVw/Evn+FOleSoLmja1wZK2HCsJMRvYhMHDI3SsPcRPEcfukHOPClHGI7\nf+04MamnZB+kRrC7t+ybkboIvlWD4xGNv0CjStBuhZ909Fte9EnE4jjLqIOy\n1ug6N+V5wMl+I6Hw7G/Zb/AyhkYzHE70qjDLsJ2EA7qlzQSHDfdX2Q4AKlyw\nXAqtFKy/UGtawgb7/osT9RQ0Q4Aj3C3PUPL5TySsv1+IeALdRrhKem2/WmHP\nKCckFPIu03apAFBJBBihaVoIDtEIBFAEBEIALoIArsLkLtoQE/p8ZdM023nu\nV6j0aGsNnc1uvL+msvJb6d16r0Vrfwzdjx3QFoGtrj7oCMatm38p4MaN6srq\nj7fopJy2OhdX8BcPia78wpO0491y5rhwLPoUVO0CWGMElp3+FHEYG1kn3Vp4\nLpB52V8IDDZ2tSravEbQCTsB3Q02wkimn91YnE1Guw7Lr8L5g5/A4CNF5K38\nNduI2AUOeJ2qgABauZ2vLdhsquaNrHWbLvZOQbV3V8OZ2DFJCLLX27fstN0C\naR2GwkEbVSh4jiCyN7Ljdsb7LQ4mMyJgbFwjZU457nM8yrct+hvFq1MZ4KgZ\nkNsNKijOSx+LKb491lfqOISxkNNgcEcrV5eqKNw0kuO2xWV+oGOGHqaC6vRD\nT8YKYAPIogpq09kWXEuBv35TCpEKkEfugkoEkkkB0F1zwhS6QBCI4Q7LoBAE\nDdOtBPZcAJxoQa06dFoIk3snbb+F6d0GxjtDjRrcXZ+681heWsZRr4XoP05J\nqgZV/fup2dalrRXK6DbHCLB5d060Aps7UY7fK6a3VzsFJ0NHPPokQPRBbNBo\n/wBFhLQHbAaU6DQpt2iSdhVII34YaAB+i5c0nc8eifEZAv7oCMvO/dAQpRTD\n5bWe6pKYHagaJIFVa1M0NsICxn1STDjlwsHUBt6ICy8URwtN2B391cdPz2GK\ni7dppZbpua3qGA0sbTWeVw/dIGXEcXNJLDWwSsVv03JnBFhyiTyt0kk7LFxf\nUE0cz2O1EA/snIeqzZb6ds0d/VNKzzm+KRR25WS+pHGPF0FhLCKLhyFr2jU0\nGlRfU0cYwHl/J42R+rnTyuVjg83Z9/VNKROaeQ3VXyo5N8qkggjvykkqAgj2\nStBv/9k=\n"},{"variant_ids":["28631151555"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591926403,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:47:31.898Z","handle":"product-name","updated_at":"2016-09-23T19:47:32.305Z","published_at":"2015-09-23T19:47:31.872Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634467331,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:33-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634467395,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:33-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315866755,"product_id":8591926403,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[{"variant_ids":["28634467331"],"attachment":"/9j/4AAQSkZJRgABAQEAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsL\nDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/\n2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIy\nMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCADwAPADASIAAhEBAxEB/8QA\nGwAAAQUBAQAAAAAAAAAAAAAAAQADBAUGAgf/xAA4EAABBAEDAgUCBQIFBAMA\nAAABAAIDEQQSITEFQRMiUWFxBoEUMpGhsSNCJDNSYtEVQ3LhFpLB/8QAGQEA\nAwEBAQAAAAAAAAAAAAAAAAECAwQF/8QAJxEBAQACAgIDAAEDBQAAAAAAAAEC\nEQMxEiEEIkEFExQyMzRCUWH/2gAMAwEAAhEDEQA/APBQgkjSkySSSQCSSSQC\nSR7IUgEkkkmCSSSQC7olDuiUHHPflPxf5jfkJnunmVrb8hKqx7X1XN9k4Bsu\nP+6PhOjhcz2cQQXSF1uSkroECE06Ymy1pr1TwOpo+FWrE45zK6iNmD+g/wCF\nRq+yh/Sd8FUJ2K04+nn/AC59oVWgiktHICSKVIAhJLskOUGaRSSQkkkkQgFS\nNIsFupWWJ0uXLOwof6kHJtVpK+d9OTNB84Krcnp82M8te0ihyjcO42IfCB5K\nKSEgkkkmCH5kSh3XXZI45KdZWofKZPKeZ+YIp49tFX9ZvwnANlx/3G3/AKU5\nWy5a93CAUyTrJv8AKP3Xcr6FdymWnaleOLn5+TX1jpx232Tkf5RXCYduno92\nKs56Y/Hy++jeSP6R+FnytDOP6ZWfdynx9J+XPcBIDdJIclaOIaS4QBRQCSRK\nFIOG0kkkIJFLukgHYGl0rQPVbzFhbDFGwCqAHysX0tnidSx29i8Wt1FZeRxv\nwoyaY9HvABF7qLk40coEcjd991aMYSAmpodr7qFS1guqdMdiyF7N2EqqK3mV\nEHAh7bB5CyXUMA48hc3eM8FXjU54fsV6P3SSVsw7ro8Id0Sg3KdZ+YJop6Me\nZvyiqx7aQ/5jP/FdPIY2zwEjQljH+1Q82cF3hNPG5XLJuvcyymGNpuSUvf6W\nugaUVm5JJrsnRJRq10SaeXnlbd1IB2qk9DelQvFt2xU3HFx2fVRydNfi++QJ\nh5Fnn/mI91o5R5FnZNnu+Sji6V86a04SSSWrzySSSQBtJBHdAN0inNIKWkIF\nhtJdFnulpKC0s+gM19Vj9gXfstdjup+53tZP6fOjrEN1uCP2Wie8wzgAkUe4\nUXtphPq0cVFt8Lp+7a5UDHy26PhP/iWnuFne1eO0PMirzAX6hUWYGO1NcLY4\nGlo5aeDZ/RUWbE1tgOs0TR4ITxqrNRl8zE8E62bsvb2URWuVK5wO3HZQtOqQ\nBtBpWsY2So4abSsWnnt8tHnhMmqFplZoTQvuumvDSCg5pb90vDJtAm5fSdJ1\nCR0uvjak06Vz9ybJ3JTRprKI9ly2xQSkjW8mV7qQ15BF37J5rwO1lR9Qc3jd\nAFw9ggbS2uF8UrTHH9AFUQebrsr3E3xWb8LLlv1dnwvfI6kHkKzcwqZ/yVpp\nB5Cs3kip5PXUUuFX8hOjSSI+UqW7zNBSHCKRQAKCKCA61BGx6prUUtXwgbPJ\ncpnUAeEQ73KB5J/T5RDnwPJoB4v4Wq6gwtcXN7GliWvN7FbKSfxsCCY7lzAT\n8hRl20wu5o1Fl6e6lRZxjcCD+qo3SUbauTlkHuizat6a8Znis3Y5wrluyos9\n4L9TDwVDi6lIGOYJHN+E7jNdkt8w3/lKY6Py3NK+WIvds01fmUV/ltjRxurK\ncuieRHd8Ha1AcHaiQ6tu6raLDRZr8wFAKPJGXmwFN8J4bbeRz8JxsJa0yNGx\nANnsU0+O0NrA86XD8oBsJwQ6Qd7b2Uotj0P8wt0dWPlNeHK0s0+Yc0PlCpoz\nI3XEQRu3e/ZKZgYxgregpscIewSfmAbRPqFxmRa3Y7wPLpHCFVELC0C+Ua2r\nkrrKjdE9p/t4CLCCwvo2gfugjc1jtxZ/hW/S7LZWni7CpRbjYV30m9BsLPl9\n4un4l1yRLkB0H4WZywBlSgeq1UrfKsvnNrLk+VHD26f5GfWVGCKQ7pLoeSCB\nRPwueUJIoI90OEycUUaSRtIgS4RsIoANO61PTcuN3TxjzeUEWx3oeKWYCvun\n4pd08uqy06hv27pZaXx9pGVhiCIAm3OFilSynS8ha3Mx25PT4J4zbg2qP8LJ\n5cZa8u3q6NpY3bTP0exWvc9rg2x7NtWreoMiY6Ix06ua2/8ASr8NwfCSNiD2\n7rid8jjRtx7Eos2JdT0fdLPKHHU4UNwRuQmRHqvm6v5T8UkjW89uD3XLpXOe\nNArVz7JQ0drbDpHFttG4urH/ACpEbg5ukuDoq033A7KJI2R0hB2DdrJVh0ot\njdofjGRvc82E6W/elf4EkR8M8h37HutC3p5GM1zIySQQSPfYKc7oP4vHZNiH\nWBsQdyAtFidJfH0qDWPPd1XdZ5ZxeGHbFYPTZWB8Gh2g9/QnevsFLyelh7Ym\nxjaN2xHB9QtdHgNJma1vB5+VXBgjkc3bk8o8lY4emXyentlY9l24cKvgww3E\ndJIKHYeq0cLAMqQUNIJCreq5WNiObHe4/tbynL70rPHU8qoND3g7FoHaladH\nNamuO/ZQ4c+KSXS6LTqPJO67e0xT64ztdmuyectmi4M5hnMl9I3Y/Cy3URWa\n/wCy0uPO3IivvXZZ3qorOd8BZcU1dO/5+Uz45lEHujVpIF4HK6XkFp3XJaUd\nTT3XVjsUFqVxpKWknsu0kbHiYRpFBDMkrSKXZAILXdELX4jdJuuQsiFpvpid\njXujfXqpz6acd+zR42KTFLj6gIn+Zgdy09wsp1TGdBMWPG/r6rYztLWNc00A\nbBVF1Joysi+wWeGVa5TfpQ4gcy+QD7Wniwudq/RThjOLg0NDbTn4Pweavvau\n5FIrSHVR/KeycghLstrCQAeSXJzLaI30ZAW+yOPNBFKHOeDR2CL0c1FmIo44\nnSPOnSdia3IUOXq8LW6GRsc4G7r+K4RlLuqSvji/yYW65KIHfZLKj/C4Qkbp\nazYUAp3+VVls3Olx9PfUkMWS1rhQdTXb2LW9dPE+Fvhu8tbey8fng8TH8dtM\nlbvY7rYfT/VxldNbG6T+owUbWeeH/KDC3eq1uPpDXtrb2/lZjqEsTMtwY4Hz\ndirhk+mNztW/ZY/qryc1waCC7j3IKMZttLMTxI/EvLeDusxOwT5+VK476iBf\nsr3HyPFa15NmqKp2Runz5MZgBkfIaBNWrx2rm/xlR8aNmXENwHXQPoVBkdOW\nF97XRr1VlK0dNEjHAeI15sHcX6KPgxmTHmc7gnv3Wktc1kup+pPQJCTK0k2A\no3WBWd8tCselwBhc++VA6yP8YNv7VnP9R05b/tZL/wBqxcvBNLv1Qd2WzgvR\nqkqXe/ol8oRpzv2KQc4d10QENPqgAglSRTIkAkN+V0PQIBAKVhZLsXIbI0A0\neCo6I5SEej487snAa9+kEjsVAljsE0SoP03mO0ugcTp7bq8nayIa7sfFhYWe\nNdMy2q8eKSSfW8EtHqd1H6nmeA90Qdqv7qXkdQgijdpf5yPRU2Piu6hlDU6t\nR5A7K5P2ouV/ECR0kzq7FS8XAHiMdYc0nelr8L6dZE2zGdNbl1KJl9OZh69B\nDm8hl/wn5zqDHH3uqCdjsDN1EHQ/0V1L02XP6doFU4WDfCbEmJkxCDKoEbai\nE03A6hjN/wAFmaoju0alOt3dXcvWp0Yy9EGPo21NbSr8DJlxpmvaa3sqb/0u\naaUfiZRzuAbVzB02ARsZ4Y0jun6nYmNyu4tMPJZN07xA/nt791nuryF0oc07\ng8qxkkZjTCGGgOXADZVmX55Cd69FE9V0W7mqgQTOimc0uOlxv7pl8LpM951m\nN4Ntc3kJ6QNHZPwxtyWA2BIzv7KtqmHlPFWy4LnzF2Rk6rNknclOyytDGQY4\nOgd+CSrQYDZHBdnogDw5rhq9+E/KMc+Lx6c4OPIyDWePW1T9aH+Kaf8AatWI\n2wwjHB1O5NLPdZxXGZrnuZGKP53V+yiXeba/7fSi7oO4UjRjs/NK5x9GtXLp\nIgBpY752W7hqOBfwj5R7oucw/wBjr9S5cITSSRQQlwkkEUEQ3R7oUimBRCCI\nQFl0mV8WWwsAO+69C8BuZhB2oWRRG5XmeNJokaaujwvVPph7svBDXNawAeUB\nRnNtMazM/Q/Fmpztx6FXXS+jHHY0jU0nsapX8/SwBqBNjuGp7EjkfTG7uHdY\nZ5Za01xkdY8A8KizcCrAVTmfTf4p73tkLDzRNH9FpY4zDvKdR/RVGd1qKLKE\nbxwdqG5UY5Xfo7pkczoc2OakiMwHcbFNR9HBc0gu83DR2Wyiy8nKf5cV7/S2\nmle9H+np82XxHYQEZ5JFLaW3tH1jFYn0s3wxLbjfqEZ8X8OKLHUB6L1yX6dG\nJiERRhorhYTrOJMJy1gc7f8At2Rk34eTd0w2TiumkLyCL+yhz47mOAIra7K1\nUmLO8f5I23Vf1LpEmRACAY3t43SxrXkxmtxjsiRrXkCz8LrByHR5QAFtfsU+\n+GduUYZo2Na0XsKUjp+AXzeIG+UcGuVpdMMblck6KOzwb9lfx4onxGgbOrfZ\nRIYHNrgC1YPmONDTNJPusd6dHJ9/SozIX450MJ99KyvWMaZ8zXBnY2SQP5Wk\nyZnSuLpKPyXKh6q3Hc5lsYedxJX8owu8mvLj48GlI7HeOSz/AO4/5XLoJC3Y\nA/Dgf/1SXwxVqDJAPUCx+xTBijdektNerq/kLpeXTDopWbmNwHwuO6dLJGbt\nbIB/tN/wgZnH81u/8qQg2Er3R1NP9lfBQNX5UBykpbomHt+i4OP/AKT+qNn/\nAE6YRCcOO8cUfuuSxzeQQhNxscopAE8BdaHD+0/onstEw0Rutn9LdU/D5DGl\n8rvvsFjQrPpeWcadpofYbopyveMQty4GucBZHracPTA939PUB6NNLPfTfVTN\nC3y2e9ra4socATysrJaq2wzH0bxgA/avdH/4lhySanNP2VxE4ADupcb2pzGQ\nrlUfA6JDiNHhxtA/VXkLjjsA8u3CgCQE3ZAXfitG4P8AynrSe06aczREObQ7\n2sn1PpxlaQ1wYw78cq4lmkO4NtPA9U1LK1wp35jyp7XhfGsPN0Zhc4OLux29\nlElwY42HZ5B83m7LX5b4gDZ79lj/AKjz3Q4Uromm+G+5KWm8ztZjqGPDNMQ2\nMEjuoJM+O0Na2mjgeivek9NfHinIy3apHbn2UfLjmeTpjAaosu3Vjy4ydKln\nUnMcNTQTaGTmeM3VuLXcuC8eYtF+i5MVN0ub7JWLxywt3pAdITdUfhU/VZLD\nbNi+4Dh/yrXIYWPO1eipepuvSXA7HkcowntfyMpeP0ry1t6tFCvzROXDnFw2\neJPZ4ooEkHU03+xC5L2u/M2j6hdLya4OkH+5jki94Hmpw990nGhVhzfdCu7S\nfhCA8h7Fp9twgW1xRHsgkmEu9kgd+VyEbSbbd37o88rgFEFI9um0OAuw5NjZ\ndAoPbstY/kD5UzAxWSShpaT6EHdQ27lX/Q4nyzAFo08oLUrRYDJo2tbC/SeO\nVrenZ7oGtEry4j0KoomiMAXSktnjZySo3r2q47mm3xepCQbHZWUeU099l5/B\nlAkeG/8AVW0Ga+Mc6iU5kxywsbQZDQLJSGQzuRZ/ZZVvUpHu0/lAXbuoPHe0\n9osaf8Q072PYJh04L3H7Kh/6k9osmz6Jl3UzZsqRpdSPjOxo7rPdcxWTtZsK\na7UB6pubqxB2PCaxc4ZMhbIbo7IaYf8Aqvx2ZEszWG/CB4U3IwTVtaKVjBjt\njcQNwO6bz85mPHejVXZTI25M936xQzwtY3zAWq98LHva2rr07qRkZE+W4/0S\nweqjxsMbt9/ZFhy2dqrqEDRq0squKWP6qDQu+e62ua3zE6Csf1YDegQNXBFI\nnbTK746pTtRB4QJv5Rd7JaHHstnGaKFJ3wXXvQR8H/chPjTPZJPeCP8AVsuh\nGwchB+NFFcrpCiXQXKIQe3QRagEQgbOxjcb191rPppoMm7ST2I4/lZWFgc8A\nlbn6dxmMpwaDtzVINfOhadzt7FDQ1uzW38BPuY090C0N7H5JWdipXDQQeKTr\nZgzYWT7Jh0riaBtc3p3qykd9p7Z5KskNb7LuPILjfDRwqwOLned23opAlFbH\nhG0XFOdLe1qNNLzvsmTKDvaaklBFo2nTiR5s0U502QDNaHbA+6iOeHBcwyeH\nMHdwUK01E2U+tEX5k3iY8mRK50xsji0caNzsmB5Nhza+6vocXwwXUBfKNbpz\nPGYa/VDPi6dg21XSYm3Hm5WtmhHYKryo2RMc4jelWkzJjMppDjvaxnWnPE5a\n7QWHjZbjLB1F1crH9dawvJDaI590Y9tMr9VAdN7bLklA7FK1bOUEr3QtBA2K\nCCSBse6KCKCJdBBEIAjddBALpqAk4rC6QBos/Fr0HoELmY4c5h+apYXA0iRu\n+/YL0npcZ/BMJcb9LQaw0eW1wWNPN/CkMZ5aNpeEPVRYNoT46Gxr4Ud7fW1a\n+AOzVw/Evn+FOleSoLmja1wZK2HCsJMRvYhMHDI3SsPcRPEcfukHOPClHGI7\nf+04MamnZB+kRrC7t+ybkboIvlWD4xGNv0CjStBuhZ909Fte9EnE4jjLqIOy\n1ug6N+V5wMl+I6Hw7G/Zb/AyhkYzHE70qjDLsJ2EA7qlzQSHDfdX2Q4AKlyw\nXAqtFKy/UGtawgb7/osT9RQ0Q4Aj3C3PUPL5TySsv1+IeALdRrhKem2/WmHP\nKCckFPIu03apAFBJBBihaVoIDtEIBFAEBEIALoIArsLkLtoQE/p8ZdM023nu\nV6j0aGsNnc1uvL+msvJb6d16r0Vrfwzdjx3QFoGtrj7oCMatm38p4MaN6srq\nj7fopJy2OhdX8BcPia78wpO0491y5rhwLPoUVO0CWGMElp3+FHEYG1kn3Vp4\nLpB52V8IDDZ2tSravEbQCTsB3Q02wkimn91YnE1Guw7Lr8L5g5/A4CNF5K38\nNduI2AUOeJ2qgABauZ2vLdhsquaNrHWbLvZOQbV3V8OZ2DFJCLLX27fstN0C\naR2GwkEbVSh4jiCyN7Ljdsb7LQ4mMyJgbFwjZU457nM8yrct+hvFq1MZ4KgZ\nkNsNKijOSx+LKb491lfqOISxkNNgcEcrV5eqKNw0kuO2xWV+oGOGHqaC6vRD\nT8YKYAPIogpq09kWXEuBv35TCpEKkEfugkoEkkkB0F1zwhS6QBCI4Q7LoBAE\nDdOtBPZcAJxoQa06dFoIk3snbb+F6d0GxjtDjRrcXZ+681heWsZRr4XoP05J\nqgZV/fup2dalrRXK6DbHCLB5d060Aps7UY7fK6a3VzsFJ0NHPPokQPRBbNBo\n/wBFhLQHbAaU6DQpt2iSdhVII34YaAB+i5c0nc8eifEZAv7oCMvO/dAQpRTD\n5bWe6pKYHagaJIFVa1M0NsICxn1STDjlwsHUBt6ICy8URwtN2B391cdPz2GK\ni7dppZbpua3qGA0sbTWeVw/dIGXEcXNJLDWwSsVv03JnBFhyiTyt0kk7LFxf\nUE0cz2O1EA/snIeqzZb6ds0d/VNKzzm+KRR25WS+pHGPF0FhLCKLhyFr2jU0\nGlRfU0cYwHl/J42R+rnTyuVjg83Z9/VNKROaeQ3VXyo5N8qkggjvykkqAgj2\nStBv/9k=\n"},{"variant_ids":["28634467395"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +233,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:53 GMT
+      - Fri, 23 Sep 2016 19:47:35 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +249,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 13/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 37/40
+      - 13/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +259,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590657987
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591926403
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/16ec5565-60a9-4bc1-8b97-655e95b57c01?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/0fbabe95-da4a-40d0-b158-b013e09bd163?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 16ec5565-60a9-4bc1-8b97-655e95b57c01
+      - 0fbabe95-da4a-40d0-b158-b013e09bd163
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +277,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590657987,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:51-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:52-04:00","published_at":"2015-09-23T14:14:50-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631151491,"product_id":8590657987,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:52-04:00","taxable":true,"barcode":null,"image_id":17193166659,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631151555,"product_id":8590657987,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:51-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314161603,"product_id":8590657987,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[{"id":17193166659,"product_id":8590657987,"position":1,"created_at":"2016-09-23T14:14:52-04:00","updated_at":"2016-09-23T14:14:52-04:00","src":"https:\/\/cdn.shopify.com\/s\/files\/1\/0677\/9563\/products\/9c9d1d19a5ccb7589ee3605cb101e477.jpg?v=1474654492","variant_ids":[28631151491]}],"image":{"id":17193166659,"product_id":8590657987,"position":1,"created_at":"2016-09-23T14:14:52-04:00","updated_at":"2016-09-23T14:14:52-04:00","src":"https:\/\/cdn.shopify.com\/s\/files\/1\/0677\/9563\/products\/9c9d1d19a5ccb7589ee3605cb101e477.jpg?v=1474654492","variant_ids":[28631151491]}}}'
+      string: '{"product":{"id":8591926403,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:33-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:35-04:00","published_at":"2015-09-23T15:47:31-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634467331,"product_id":8591926403,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:35-04:00","taxable":true,"barcode":null,"image_id":17195976003,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634467395,"product_id":8591926403,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:33-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315866755,"product_id":8591926403,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[{"id":17195976003,"product_id":8591926403,"position":1,"created_at":"2016-09-23T15:47:35-04:00","updated_at":"2016-09-23T15:47:35-04:00","src":"https:\/\/cdn.shopify.com\/s\/files\/1\/0677\/9563\/products\/9c9d1d19a5ccb7589ee3605cb101e477.jpg?v=1474660055","variant_ids":[28634467331]}],"image":{"id":17195976003,"product_id":8591926403,"position":1,"created_at":"2016-09-23T15:47:35-04:00","updated_at":"2016-09-23T15:47:35-04:00","src":"https:\/\/cdn.shopify.com\/s\/files\/1\/0677\/9563\/products\/9c9d1d19a5ccb7589ee3605cb101e477.jpg?v=1474660055","variant_ids":[28634467331]}}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:53 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:36 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590657987.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591926403.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,7 +304,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:53 GMT
+      - Fri, 23 Sep 2016 19:47:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -320,9 +320,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
+      - 10/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
+      - 10/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -330,9 +330,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ebd2dd90-fa6d-4bb2-9ba6-f6882b26f43c?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/861ac06d-80b2-4d16-b2e9-32cbb8feb106?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - ebd2dd90-fa6d-4bb2-9ba6-f6882b26f43c
+      - 861ac06d-80b2-4d16-b2e9-32cbb8feb106
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -346,13 +346,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590657987,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:51-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:52-04:00","published_at":"2015-09-23T14:14:50-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631151491,"product_id":8590657987,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:52-04:00","taxable":true,"barcode":null,"image_id":17193166659,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631151555,"product_id":8590657987,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:51-04:00","updated_at":"2016-09-23T14:14:51-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314161603,"product_id":8590657987,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[{"id":17193166659,"product_id":8590657987,"position":1,"created_at":"2016-09-23T14:14:52-04:00","updated_at":"2016-09-23T14:14:52-04:00","src":"https:\/\/cdn.shopify.com\/s\/files\/1\/0677\/9563\/products\/9c9d1d19a5ccb7589ee3605cb101e477.jpg?v=1474654492","variant_ids":[28631151491]}],"image":{"id":17193166659,"product_id":8590657987,"position":1,"created_at":"2016-09-23T14:14:52-04:00","updated_at":"2016-09-23T14:14:52-04:00","src":"https:\/\/cdn.shopify.com\/s\/files\/1\/0677\/9563\/products\/9c9d1d19a5ccb7589ee3605cb101e477.jpg?v=1474654492","variant_ids":[28631151491]}}}'
+      string: '{"product":{"id":8591926403,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:33-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:35-04:00","published_at":"2015-09-23T15:47:31-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634467331,"product_id":8591926403,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:35-04:00","taxable":true,"barcode":null,"image_id":17195976003,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634467395,"product_id":8591926403,"title":"slave-sku","price":"19.99","sku":"slave-sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"slave-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:33-04:00","updated_at":"2016-09-23T15:47:33-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315866755,"product_id":8591926403,"name":"Title","position":1,"values":["master-sku","slave-sku"]}],"images":[{"id":17195976003,"product_id":8591926403,"position":1,"created_at":"2016-09-23T15:47:35-04:00","updated_at":"2016-09-23T15:47:35-04:00","src":"https:\/\/cdn.shopify.com\/s\/files\/1\/0677\/9563\/products\/9c9d1d19a5ccb7589ee3605cb101e477.jpg?v=1474660055","variant_ids":[28634467331]}],"image":{"id":17195976003,"product_id":8591926403,"position":1,"created_at":"2016-09-23T15:47:35-04:00","updated_at":"2016-09-23T15:47:35-04:00","src":"https:\/\/cdn.shopify.com\/s\/files\/1\/0677\/9563\/products\/9c9d1d19a5ccb7589ee3605cb101e477.jpg?v=1474660055","variant_ids":[28634467331]}}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:53 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:37 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590657987.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591926403.json
     body:
       encoding: US-ASCII
       string: ''
@@ -373,7 +373,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:54 GMT
+      - Fri, 23 Sep 2016 19:47:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -389,9 +389,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 10/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 10/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -401,9 +401,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e2e13d0b-900a-4313-b68c-081abb10c375?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/66e1f5fb-3920-4466-b5e1-85b8a9c80083?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - e2e13d0b-900a-4313-b68c-081abb10c375
+      - 66e1f5fb-3920-4466-b5e1-85b8a9c80083
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -419,5 +419,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:54 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Export_a_bundled_Spree_product_with_its_assembly_on_Shopify/creates_a_bundle_product_with_a_proper_variant_sku.yml
+++ b/spec/cassettes/Export_a_bundled_Spree_product_with_its_assembly_on_Shopify/creates_a_bundle_product_with_a_proper_variant_sku.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:31 GMT
+      - Fri, 23 Sep 2016 20:24:05 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 30/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 30/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d62e25e7-bf51-4393-8bd9-d908cf1bd5d8?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8cab316e-7eb8-40c7-8210-8547cb56f265?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - d62e25e7-bf51-4393-8bd9-d908cf1bd5d8
+      - 8cab316e-7eb8-40c7-8210-8547cb56f265
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:31 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:05 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
-      string: '{"product":{"title":"Product #14 - 6723","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:31.781Z","updated_at":"2016-09-23T18:14:31.802Z","published_at":"2015-09-23T18:14:31.745Z","vendor":"Default
-        Vendor","handle":"product-14-6723","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-25","inventory_management":"shopify","updated_at":"2016-09-23T18:14:31.795Z","option1":"SKU-25"}]}}'
+      string: '{"product":{"title":"Product #2 - 4696","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T20:24:05.252Z","updated_at":"2016-09-23T20:24:05.281Z","published_at":"2015-09-23T20:24:05.229Z","vendor":"Default
+        Vendor","handle":"product-2-4696","options":[],"variants":[]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:32 GMT
+      - Fri, 23 Sep 2016 20:24:05 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590652419
+      - https://glossier-pop-staging.myshopify.com/admin/products/8592444675
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/503f1c07-9e73-497b-a90a-428004993335?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/84be29ff-d65d-4195-af46-6fe796f204c1?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 503f1c07-9e73-497b-a90a-428004993335
+      - 84be29ff-d65d-4195-af46-6fe796f204c1
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,16 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590652419,"title":"Product #14 - 6723","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:32-04:00","handle":"product-14-6723","updated_at":"2016-09-23T14:14:32-04:00","published_at":"2015-09-23T14:14:31-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631138947,"product_id":8590652419,"title":"SKU-25","price":"19.99","sku":"SKU-25","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-25","option2":null,"option3":null,"created_at":"2016-09-23T14:14:32-04:00","updated_at":"2016-09-23T14:14:32-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314154627,"product_id":8590652419,"name":"Title","position":1,"values":["SKU-25"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592444675,"title":"Product #2 - 4696","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T16:24:05-04:00","handle":"product-2-4696","updated_at":"2016-09-23T16:24:05-04:00","published_at":"2015-09-23T16:24:05-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28635723459,"product_id":8592444675,"title":"Default
+        Title","price":"0.00","sku":"","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"Default
+        Title","option2":null,"option3":null,"created_at":"2016-09-23T16:24:05-04:00","updated_at":"2016-09-23T16:24:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"kg","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316543555,"product_id":8592444675,"name":"Title","position":1,"values":["Default
+        Title"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:32 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:05 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590652419.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592444675.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +164,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:32 GMT
+      - Fri, 23 Sep 2016 20:24:06 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +180,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 30/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 30/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +190,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/14214db4-cd96-4c6c-9bfc-b892f3aa62a6?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/bd031fab-4fa2-48c3-9485-6bbc78ccb2cd?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 14214db4-cd96-4c6c-9bfc-b892f3aa62a6
+      - bd031fab-4fa2-48c3-9485-6bbc78ccb2cd
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,858 +206,16 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590652419,"title":"Product #14 - 6723","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:32-04:00","handle":"product-14-6723","updated_at":"2016-09-23T14:14:32-04:00","published_at":"2015-09-23T14:14:31-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631138947,"product_id":8590652419,"title":"SKU-25","price":"19.99","sku":"SKU-25","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-25","option2":null,"option3":null,"created_at":"2016-09-23T14:14:32-04:00","updated_at":"2016-09-23T14:14:32-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314154627,"product_id":8590652419,"name":"Title","position":1,"values":["SKU-25"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592444675,"title":"Product #2 - 4696","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T16:24:05-04:00","handle":"product-2-4696","updated_at":"2016-09-23T16:24:05-04:00","published_at":"2015-09-23T16:24:05-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28635723459,"product_id":8592444675,"title":"Default
+        Title","price":"0.00","sku":"","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"Default
+        Title","option2":null,"option3":null,"created_at":"2016-09-23T16:24:05-04:00","updated_at":"2016-09-23T16:24:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"kg","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316543555,"product_id":8592444675,"name":"Title","position":1,"values":["Default
+        Title"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:32 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590652419.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590652419,"title":"Product #14 - 6723","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:31.781Z","handle":"product-14-6723","updated_at":"2016-09-23T18:14:31.802Z","published_at":"2015-09-23T18:14:31.745Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631138947,"title":"SKU-25","price":"19.99","sku":"SKU-25","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-25","option2":null,"option3":null,"created_at":"2016-09-23T14:14:32-04:00","updated_at":"2016-09-23T14:14:32-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314154627,"product_id":8590652419,"name":"Title","position":1,"values":["SKU-25"]}],"images":[{"variant_ids":["28631138947"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:33 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590652419
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/a19319c1-63ee-4983-8aa5-4e70ce880e43?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - a19319c1-63ee-4983-8aa5-4e70ce880e43
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590652419,"title":"Product #14 - 6723","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:32-04:00","handle":"product-14-6723","updated_at":"2016-09-23T14:14:33-04:00","published_at":"2015-09-23T14:14:31-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631138947,"product_id":8590652419,"title":"SKU-25","price":"19.99","sku":"SKU-25","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-25","option2":null,"option3":null,"created_at":"2016-09-23T14:14:32-04:00","updated_at":"2016-09-23T14:14:32-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314154627,"product_id":8590652419,"name":"Title","position":1,"values":["SKU-25"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:33 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:33 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 30/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 30/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/907b4b43-5997-4406-9cf6-77f278f7f204?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 907b4b43-5997-4406-9cf6-77f278f7f204
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:33 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #15 - 9470","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:33.754Z","updated_at":"2016-09-23T18:14:33.784Z","published_at":"2015-09-23T18:14:33.742Z","vendor":"Default
-        Vendor","handle":"product-15-9470","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-26","inventory_management":"shopify","updated_at":"2016-09-23T18:14:33.779Z","option1":"SKU-26"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:34 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590652931
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/786eb130-6fc9-4642-9735-6815c397492b?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 786eb130-6fc9-4642-9735-6815c397492b
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590652931,"title":"Product #15 - 9470","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:34-04:00","handle":"product-15-9470","updated_at":"2016-09-23T14:14:34-04:00","published_at":"2015-09-23T14:14:33-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631140995,"product_id":8590652931,"title":"SKU-26","price":"19.99","sku":"SKU-26","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-26","option2":null,"option3":null,"created_at":"2016-09-23T14:14:34-04:00","updated_at":"2016-09-23T14:14:34-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314155203,"product_id":8590652931,"name":"Title","position":1,"values":["SKU-26"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:34 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590652931.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:34 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 30/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 30/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/6effa1d0-2907-4ed5-927f-c8e8a9a90cf7?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 6effa1d0-2907-4ed5-927f-c8e8a9a90cf7
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590652931,"title":"Product #15 - 9470","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:34-04:00","handle":"product-15-9470","updated_at":"2016-09-23T14:14:34-04:00","published_at":"2015-09-23T14:14:33-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631140995,"product_id":8590652931,"title":"SKU-26","price":"19.99","sku":"SKU-26","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-26","option2":null,"option3":null,"created_at":"2016-09-23T14:14:34-04:00","updated_at":"2016-09-23T14:14:34-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314155203,"product_id":8590652931,"name":"Title","position":1,"values":["SKU-26"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:34 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590652931.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590652931,"title":"Product #15 - 9470","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:33.754Z","handle":"product-15-9470","updated_at":"2016-09-23T18:14:33.784Z","published_at":"2015-09-23T18:14:33.742Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631140995,"title":"SKU-26","price":"19.99","sku":"SKU-26","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-26","option2":null,"option3":null,"created_at":"2016-09-23T14:14:34-04:00","updated_at":"2016-09-23T14:14:34-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314155203,"product_id":8590652931,"name":"Title","position":1,"values":["SKU-26"]}],"images":[{"variant_ids":["28631140995"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:35 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590652931
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/bf641405-1efc-45a4-bc84-707784e73331?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - bf641405-1efc-45a4-bc84-707784e73331
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590652931,"title":"Product #15 - 9470","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:34-04:00","handle":"product-15-9470","updated_at":"2016-09-23T14:14:35-04:00","published_at":"2015-09-23T14:14:33-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631140995,"product_id":8590652931,"title":"SKU-26","price":"19.99","sku":"SKU-26","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-26","option2":null,"option3":null,"created_at":"2016-09-23T14:14:34-04:00","updated_at":"2016-09-23T14:14:34-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314155203,"product_id":8590652931,"name":"Title","position":1,"values":["SKU-26"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:35 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:35 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/467cdd0c-f349-4b58-8f5c-9cd1989b3eb5?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 467cdd0c-f349-4b58-8f5c-9cd1989b3eb5
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:35 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #16 - 5785","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:35.558Z","updated_at":"2016-09-23T18:14:35.582Z","published_at":"2015-09-23T18:14:35.546Z","vendor":"Default
-        Vendor","handle":"product-16-5785","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-27","inventory_management":"shopify","updated_at":"2016-09-23T18:14:35.577Z","option1":"SKU-27"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:36 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590653507
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/84a13e57-e4fe-47f6-8aa9-9e1fda53ddbf?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 84a13e57-e4fe-47f6-8aa9-9e1fda53ddbf
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590653507,"title":"Product #16 - 5785","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:35-04:00","handle":"product-16-5785","updated_at":"2016-09-23T14:14:36-04:00","published_at":"2015-09-23T14:14:35-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631141635,"product_id":8590653507,"title":"SKU-27","price":"19.99","sku":"SKU-27","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-27","option2":null,"option3":null,"created_at":"2016-09-23T14:14:35-04:00","updated_at":"2016-09-23T14:14:35-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314155779,"product_id":8590653507,"name":"Title","position":1,"values":["SKU-27"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:36 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590653507.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:36 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/686123fe-2272-4649-8b7c-6a442bfe688b?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 686123fe-2272-4649-8b7c-6a442bfe688b
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590653507,"title":"Product #16 - 5785","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:35-04:00","handle":"product-16-5785","updated_at":"2016-09-23T14:14:36-04:00","published_at":"2015-09-23T14:14:35-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631141635,"product_id":8590653507,"title":"SKU-27","price":"19.99","sku":"SKU-27","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-27","option2":null,"option3":null,"created_at":"2016-09-23T14:14:35-04:00","updated_at":"2016-09-23T14:14:35-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314155779,"product_id":8590653507,"name":"Title","position":1,"values":["SKU-27"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:36 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590653507.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590653507,"title":"Product #16 - 5785","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:35.558Z","handle":"product-16-5785","updated_at":"2016-09-23T18:14:35.582Z","published_at":"2015-09-23T18:14:35.546Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631141635,"title":"SKU-27","price":"19.99","sku":"SKU-27","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-27","option2":null,"option3":null,"created_at":"2016-09-23T14:14:35-04:00","updated_at":"2016-09-23T14:14:35-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314155779,"product_id":8590653507,"name":"Title","position":1,"values":["SKU-27"]}],"images":[{"variant_ids":["28631141635"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:37 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590653507
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1906e2cd-8a3f-4380-b93b-516dd248ca51?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 1906e2cd-8a3f-4380-b93b-516dd248ca51
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590653507,"title":"Product #16 - 5785","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:35-04:00","handle":"product-16-5785","updated_at":"2016-09-23T14:14:36-04:00","published_at":"2015-09-23T14:14:35-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631141635,"product_id":8590653507,"title":"SKU-27","price":"19.99","sku":"SKU-27","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-27","option2":null,"option3":null,"created_at":"2016-09-23T14:14:35-04:00","updated_at":"2016-09-23T14:14:35-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314155779,"product_id":8590653507,"name":"Title","position":1,"values":["SKU-27"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:37 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:37 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 31/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/a59185ef-a390-4968-ac5d-f54a85888beb?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - a59185ef-a390-4968-ac5d-f54a85888beb
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:37 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #17 - 5358","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:37.311Z","updated_at":"2016-09-23T18:14:37.350Z","published_at":"2015-09-23T18:14:37.299Z","vendor":"Default
-        Vendor","handle":"product-17-5358","options":[{"name":"foo-size-13"},{"name":"foo-size-14"},{"name":"foo-size-15"}],"variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKUS-M/SKUS-1/SKUS-2/SKUS-3","updated_at":"2016-09-23T18:14:37.348Z","option1":"S","option2":"S","option3":"S"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:37 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 32/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 32/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590653955
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1d49727f-23f5-481d-b6cd-89ab6ccb96c0?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 1d49727f-23f5-481d-b6cd-89ab6ccb96c0
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590653955,"title":"Product #17 - 5358","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:37-04:00","handle":"product-17-5358","updated_at":"2016-09-23T14:14:37-04:00","published_at":"2015-09-23T14:14:37-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631142659,"product_id":8590653955,"title":"S
-        \/ S \/ S","price":"19.99","sku":"SKUS-M\/SKUS-1\/SKUS-2\/SKUS-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"S","option2":"S","option3":"S","created_at":"2016-09-23T14:14:37-04:00","updated_at":"2016-09-23T14:14:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314156227,"product_id":8590653955,"name":"foo-size-13","position":1,"values":["S"]},{"id":10314156291,"product_id":8590653955,"name":"foo-size-14","position":2,"values":["S"]},{"id":10314156355,"product_id":8590653955,"name":"foo-size-15","position":3,"values":["S"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:38 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590653955.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:38 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 32/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 32/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/da34d492-6365-44ac-bbb9-eddc3a195247?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - da34d492-6365-44ac-bbb9-eddc3a195247
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590653955,"title":"Product #17 - 5358","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:37-04:00","handle":"product-17-5358","updated_at":"2016-09-23T14:14:37-04:00","published_at":"2015-09-23T14:14:37-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631142659,"product_id":8590653955,"title":"S
-        \/ S \/ S","price":"19.99","sku":"SKUS-M\/SKUS-1\/SKUS-2\/SKUS-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"S","option2":"S","option3":"S","created_at":"2016-09-23T14:14:37-04:00","updated_at":"2016-09-23T14:14:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314156227,"product_id":8590653955,"name":"foo-size-13","position":1,"values":["S"]},{"id":10314156291,"product_id":8590653955,"name":"foo-size-14","position":2,"values":["S"]},{"id":10314156355,"product_id":8590653955,"name":"foo-size-15","position":3,"values":["S"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:38 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:06 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590653955.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592444675.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1075,7 +236,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:38 GMT
+      - Fri, 23 Sep 2016 20:24:06 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -1091,9 +252,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 32/40
+      - 4/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 32/40
+      - 4/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -1103,9 +264,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/a5fcc7b1-4a7c-46fd-98d5-507e027ad19e?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/bd18677c-916c-4f41-aa87-fa603c0819c3?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - a5fcc7b1-4a7c-46fd-98d5-507e027ad19e
+      - bd18677c-916c-4f41-aa87-fa603c0819c3
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -1121,5 +282,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:38 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Export_a_bundled_Spree_product_with_its_assembly_on_Shopify/creates_a_bundle_product_with_the_option_types.yml
+++ b/spec/cassettes/Export_a_bundled_Spree_product_with_its_assembly_on_Shopify/creates_a_bundle_product_with_the_option_types.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:25:38 GMT
+      - Fri, 23 Sep 2016 20:24:04 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/071bd4eb-07e3-4bdb-b779-24c81649111c?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/d8a5681a-e9da-4262-89e0-680f8970554f?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 071bd4eb-07e3-4bdb-b779-24c81649111c
+      - d8a5681a-e9da-4262-89e0-680f8970554f
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:38 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:04 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
-      string: '{"product":{"title":"Product #1 - 7281","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:25:38.037Z","updated_at":"2016-09-23T18:25:38.118Z","published_at":"2015-09-23T18:25:36.794Z","vendor":"Default
-        Vendor","handle":"product-1-7281","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-1","inventory_management":"shopify","updated_at":"2016-09-23T18:25:38.100Z","option1":"SKU-1"}]}}'
+      string: '{"product":{"title":"Product #1 - 7844","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T20:24:03.536Z","updated_at":"2016-09-23T20:24:03.595Z","published_at":"2015-09-23T20:24:02.601Z","vendor":"Default
+        Vendor","handle":"product-1-7844","options":[],"variants":[]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:25:38 GMT
+      - Fri, 23 Sep 2016 20:24:04 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590829635
+      - https://glossier-pop-staging.myshopify.com/admin/products/8592444291
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/259ebdf2-ff57-4848-99bc-92d4002f5806?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/1b470ef2-8c86-42a8-a5d6-66876e5d0c1e?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 259ebdf2-ff57-4848-99bc-92d4002f5806
+      - 1b470ef2-8c86-42a8-a5d6-66876e5d0c1e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,16 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590829635,"title":"Product #1 - 7281","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:38-04:00","handle":"product-1-7281","updated_at":"2016-09-23T14:25:38-04:00","published_at":"2015-09-23T14:25:36-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631603651,"product_id":8590829635,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:25:38-04:00","updated_at":"2016-09-23T14:25:38-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314385091,"product_id":8590829635,"name":"Title","position":1,"values":["SKU-1"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592444291,"title":"Product #1 - 7844","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T16:24:04-04:00","handle":"product-1-7844","updated_at":"2016-09-23T16:24:04-04:00","published_at":"2015-09-23T16:24:02-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28635722307,"product_id":8592444291,"title":"Default
+        Title","price":"0.00","sku":"","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"Default
+        Title","option2":null,"option3":null,"created_at":"2016-09-23T16:24:04-04:00","updated_at":"2016-09-23T16:24:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"kg","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316542979,"product_id":8592444291,"name":"Title","position":1,"values":["Default
+        Title"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:39 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:04 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590829635.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592444291.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,288 +164,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:25:39 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d8dd2964-271c-4a68-aa6b-f8c902ac251d?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - d8dd2964-271c-4a68-aa6b-f8c902ac251d
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590829635,"title":"Product #1 - 7281","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:38-04:00","handle":"product-1-7281","updated_at":"2016-09-23T14:25:38-04:00","published_at":"2015-09-23T14:25:36-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631603651,"product_id":8590829635,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:25:38-04:00","updated_at":"2016-09-23T14:25:38-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314385091,"product_id":8590829635,"name":"Title","position":1,"values":["SKU-1"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:39 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590829635.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590829635,"title":"Product #1 - 7281","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:25:38.037Z","handle":"product-1-7281","updated_at":"2016-09-23T18:25:38.118Z","published_at":"2015-09-23T18:25:36.794Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631603651,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:25:38-04:00","updated_at":"2016-09-23T14:25:38-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314385091,"product_id":8590829635,"name":"Title","position":1,"values":["SKU-1"]}],"images":[{"variant_ids":["28631603651"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:39 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590829635
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c00c1c41-d8af-4a69-b651-eababfffe751?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - c00c1c41-d8af-4a69-b651-eababfffe751
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590829635,"title":"Product #1 - 7281","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:38-04:00","handle":"product-1-7281","updated_at":"2016-09-23T14:25:39-04:00","published_at":"2015-09-23T14:25:36-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631603651,"product_id":8590829635,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:25:38-04:00","updated_at":"2016-09-23T14:25:38-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314385091,"product_id":8590829635,"name":"Title","position":1,"values":["SKU-1"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:39 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:40 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/13f605c4-d484-46b3-b22f-6a9655a2ea88?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 13f605c4-d484-46b3-b22f-6a9655a2ea88
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:40 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #2 - 6094","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:25:40.034Z","updated_at":"2016-09-23T18:25:40.065Z","published_at":"2015-09-23T18:25:40.021Z","vendor":"Default
-        Vendor","handle":"product-2-6094","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-2","inventory_management":"shopify","updated_at":"2016-09-23T18:25:40.058Z","option1":"SKU-2"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:40 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590830019
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/8bde7714-b1c7-414b-a636-6d0431816ac5?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 8bde7714-b1c7-414b-a636-6d0431816ac5
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590830019,"title":"Product #2 - 6094","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:40-04:00","handle":"product-2-6094","updated_at":"2016-09-23T14:25:40-04:00","published_at":"2015-09-23T14:25:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631605059,"product_id":8590830019,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:25:40-04:00","updated_at":"2016-09-23T14:25:40-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314385603,"product_id":8590830019,"name":"Title","position":1,"values":["SKU-2"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:40 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590830019.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:41 GMT
+      - Fri, 23 Sep 2016 20:24:04 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -468,9 +190,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/89a391fb-5399-47cf-8fbb-55d41a04d2f7?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/cd672fca-006d-48ff-86b0-196efb3119bd?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 89a391fb-5399-47cf-8fbb-55d41a04d2f7
+      - cd672fca-006d-48ff-86b0-196efb3119bd
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -484,577 +206,16 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590830019,"title":"Product #2 - 6094","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:40-04:00","handle":"product-2-6094","updated_at":"2016-09-23T14:25:40-04:00","published_at":"2015-09-23T14:25:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631605059,"product_id":8590830019,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:25:40-04:00","updated_at":"2016-09-23T14:25:40-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314385603,"product_id":8590830019,"name":"Title","position":1,"values":["SKU-2"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592444291,"title":"Product #1 - 7844","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T16:24:04-04:00","handle":"product-1-7844","updated_at":"2016-09-23T16:24:04-04:00","published_at":"2015-09-23T16:24:02-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28635722307,"product_id":8592444291,"title":"Default
+        Title","price":"0.00","sku":"","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"Default
+        Title","option2":null,"option3":null,"created_at":"2016-09-23T16:24:04-04:00","updated_at":"2016-09-23T16:24:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"kg","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316542979,"product_id":8592444291,"name":"Title","position":1,"values":["Default
+        Title"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:41 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590830019.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590830019,"title":"Product #2 - 6094","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:25:40.034Z","handle":"product-2-6094","updated_at":"2016-09-23T18:25:40.065Z","published_at":"2015-09-23T18:25:40.021Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631605059,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:25:40-04:00","updated_at":"2016-09-23T14:25:40-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314385603,"product_id":8590830019,"name":"Title","position":1,"values":["SKU-2"]}],"images":[{"variant_ids":["28631605059"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:41 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590830019
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/5599833b-abb8-4ff2-b323-b18c11a8a4aa?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 5599833b-abb8-4ff2-b323-b18c11a8a4aa
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590830019,"title":"Product #2 - 6094","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:40-04:00","handle":"product-2-6094","updated_at":"2016-09-23T14:25:41-04:00","published_at":"2015-09-23T14:25:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631605059,"product_id":8590830019,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:25:40-04:00","updated_at":"2016-09-23T14:25:40-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314385603,"product_id":8590830019,"name":"Title","position":1,"values":["SKU-2"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:41 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:42 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ef7149fa-75c8-49ae-af8e-6fec73d6f478?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - ef7149fa-75c8-49ae-af8e-6fec73d6f478
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:42 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #3 - 4853","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:25:41.923Z","updated_at":"2016-09-23T18:25:41.946Z","published_at":"2015-09-23T18:25:41.899Z","vendor":"Default
-        Vendor","handle":"product-3-4853","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-3","inventory_management":"shopify","updated_at":"2016-09-23T18:25:41.942Z","option1":"SKU-3"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:42 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590830467
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/eb143f4c-da8d-4731-8187-f6d616e648e8?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - eb143f4c-da8d-4731-8187-f6d616e648e8
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590830467,"title":"Product #3 - 4853","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:42-04:00","handle":"product-3-4853","updated_at":"2016-09-23T14:25:42-04:00","published_at":"2015-09-23T14:25:41-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631605891,"product_id":8590830467,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:25:42-04:00","updated_at":"2016-09-23T14:25:42-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314386179,"product_id":8590830467,"name":"Title","position":1,"values":["SKU-3"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:42 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590830467.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:42 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/4428fc6e-2806-416e-8b25-9cf7654ccd07?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 4428fc6e-2806-416e-8b25-9cf7654ccd07
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590830467,"title":"Product #3 - 4853","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:42-04:00","handle":"product-3-4853","updated_at":"2016-09-23T14:25:42-04:00","published_at":"2015-09-23T14:25:41-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631605891,"product_id":8590830467,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:25:42-04:00","updated_at":"2016-09-23T14:25:42-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314386179,"product_id":8590830467,"name":"Title","position":1,"values":["SKU-3"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:42 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590830467.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590830467,"title":"Product #3 - 4853","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:25:41.923Z","handle":"product-3-4853","updated_at":"2016-09-23T18:25:41.946Z","published_at":"2015-09-23T18:25:41.899Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631605891,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:25:42-04:00","updated_at":"2016-09-23T14:25:42-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314386179,"product_id":8590830467,"name":"Title","position":1,"values":["SKU-3"]}],"images":[{"variant_ids":["28631605891"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:43 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590830467
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/9779087b-7fe8-4d04-af2c-8caf0d5c4b72?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 9779087b-7fe8-4d04-af2c-8caf0d5c4b72
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590830467,"title":"Product #3 - 4853","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:42-04:00","handle":"product-3-4853","updated_at":"2016-09-23T14:25:43-04:00","published_at":"2015-09-23T14:25:41-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631605891,"product_id":8590830467,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:25:42-04:00","updated_at":"2016-09-23T14:25:42-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314386179,"product_id":8590830467,"name":"Title","position":1,"values":["SKU-3"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:43 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:44 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/3959a9db-2993-4363-9896-f9bfaa42ab44?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 3959a9db-2993-4363-9896-f9bfaa42ab44
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:44 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #4 - 9771","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:25:43.791Z","updated_at":"2016-09-23T18:25:43.855Z","published_at":"2015-09-23T18:25:43.778Z","vendor":"Default
-        Vendor","handle":"product-4-9771","options":[{"name":"foo-size-1"},{"name":"foo-size-2"},{"name":"foo-size-3"}],"variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKUS-M/SKUS-1/SKUS-2/SKUS-3","updated_at":"2016-09-23T18:25:43.852Z","option1":"S","option2":"S","option3":"S"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:44 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590831043
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/4f034685-0c8a-47d8-80da-c7b5f86a1c83?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 4f034685-0c8a-47d8-80da-c7b5f86a1c83
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590831043,"title":"Product #4 - 9771","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:44-04:00","handle":"product-4-9771","updated_at":"2016-09-23T14:25:44-04:00","published_at":"2015-09-23T14:25:43-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631607107,"product_id":8590831043,"title":"S
-        \/ S \/ S","price":"19.99","sku":"SKUS-M\/SKUS-1\/SKUS-2\/SKUS-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"S","option2":"S","option3":"S","created_at":"2016-09-23T14:25:44-04:00","updated_at":"2016-09-23T14:25:44-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314386883,"product_id":8590831043,"name":"foo-size-1","position":1,"values":["S"]},{"id":10314386947,"product_id":8590831043,"name":"foo-size-2","position":2,"values":["S"]},{"id":10314387011,"product_id":8590831043,"name":"foo-size-3","position":3,"values":["S"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:44 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590831043.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:25:44 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1b49c386-0978-43e5-a31a-c749ee751979?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 1b49c386-0978-43e5-a31a-c749ee751979
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590831043,"title":"Product #4 - 9771","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:25:44-04:00","handle":"product-4-9771","updated_at":"2016-09-23T14:25:44-04:00","published_at":"2015-09-23T14:25:43-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631607107,"product_id":8590831043,"title":"S
-        \/ S \/ S","price":"19.99","sku":"SKUS-M\/SKUS-1\/SKUS-2\/SKUS-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"S","option2":"S","option3":"S","created_at":"2016-09-23T14:25:44-04:00","updated_at":"2016-09-23T14:25:44-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314386883,"product_id":8590831043,"name":"foo-size-1","position":1,"values":["S"]},{"id":10314386947,"product_id":8590831043,"name":"foo-size-2","position":2,"values":["S"]},{"id":10314387011,"product_id":8590831043,"name":"foo-size-3","position":3,"values":["S"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:44 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:04 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590831043.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592444291.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1075,7 +236,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:25:45 GMT
+      - Fri, 23 Sep 2016 20:24:05 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -1091,9 +252,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 3/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 3/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -1103,9 +264,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/03210ffc-45a5-4375-91c5-8acf2fb8ee03?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/0d5e4d7b-4582-4569-bd5f-dbcbd9e13c20?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 03210ffc-45a5-4375-91c5-8acf2fb8ee03
+      - 0d5e4d7b-4582-4569-bd5f-dbcbd9e13c20
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -1121,5 +282,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:25:45 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Export_a_bundled_Spree_product_with_its_assembly_on_Shopify/creates_a_bundle_product_with_the_variant_permutation.yml
+++ b/spec/cassettes/Export_a_bundled_Spree_product_with_its_assembly_on_Shopify/creates_a_bundle_product_with_the_variant_permutation.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:18 GMT
+      - Fri, 23 Sep 2016 20:24:07 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 24/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 24/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/455bd8bd-f18d-4ac2-806e-a53b525b91cf?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/d173c1d2-8a20-43bc-92a8-501852207ca8?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 455bd8bd-f18d-4ac2-806e-a53b525b91cf
+      - d173c1d2-8a20-43bc-92a8-501852207ca8
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:18 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:07 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
-      string: '{"product":{"title":"Product #6 - 6452","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:18.699Z","updated_at":"2016-09-23T18:14:18.720Z","published_at":"2015-09-23T18:14:18.663Z","vendor":"Default
-        Vendor","handle":"product-6-6452","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-17","inventory_management":"shopify","updated_at":"2016-09-23T18:14:18.714Z","option1":"SKU-17"}]}}'
+      string: '{"product":{"title":"Product #3 - 6629","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T20:24:06.853Z","updated_at":"2016-09-23T20:24:06.879Z","published_at":"2015-09-23T20:24:06.829Z","vendor":"Default
+        Vendor","handle":"product-3-6629","options":[],"variants":[]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:19 GMT
+      - Fri, 23 Sep 2016 20:24:08 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 4/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 4/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590647747
+      - https://glossier-pop-staging.myshopify.com/admin/products/8592445059
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/3da05c95-d7e9-4a22-a0bd-4456b71d1ad3?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/5116706e-df89-461e-992f-defb375a694e?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 3da05c95-d7e9-4a22-a0bd-4456b71d1ad3
+      - 5116706e-df89-461e-992f-defb375a694e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,16 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590647747,"title":"Product #6 - 6452","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:19-04:00","handle":"product-6-6452","updated_at":"2016-09-23T14:14:19-04:00","published_at":"2015-09-23T14:14:18-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631128003,"product_id":8590647747,"title":"SKU-17","price":"19.99","sku":"SKU-17","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-17","option2":null,"option3":null,"created_at":"2016-09-23T14:14:19-04:00","updated_at":"2016-09-23T14:14:19-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314148931,"product_id":8590647747,"name":"Title","position":1,"values":["SKU-17"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592445059,"title":"Product #3 - 6629","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T16:24:07-04:00","handle":"product-3-6629","updated_at":"2016-09-23T16:24:07-04:00","published_at":"2015-09-23T16:24:06-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28635724931,"product_id":8592445059,"title":"Default
+        Title","price":"0.00","sku":"","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"Default
+        Title","option2":null,"option3":null,"created_at":"2016-09-23T16:24:07-04:00","updated_at":"2016-09-23T16:24:07-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"kg","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316544067,"product_id":8592445059,"name":"Title","position":1,"values":["Default
+        Title"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:19 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:08 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590647747.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592445059.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +164,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:19 GMT
+      - Fri, 23 Sep 2016 20:24:08 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +180,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +190,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/f55de086-7ef5-4216-8558-e43347bb2f58?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8f9c9daf-51f1-45d0-92a4-e35dc64c1933?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - f55de086-7ef5-4216-8558-e43347bb2f58
+      - 8f9c9daf-51f1-45d0-92a4-e35dc64c1933
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,858 +206,16 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590647747,"title":"Product #6 - 6452","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:19-04:00","handle":"product-6-6452","updated_at":"2016-09-23T14:14:19-04:00","published_at":"2015-09-23T14:14:18-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631128003,"product_id":8590647747,"title":"SKU-17","price":"19.99","sku":"SKU-17","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-17","option2":null,"option3":null,"created_at":"2016-09-23T14:14:19-04:00","updated_at":"2016-09-23T14:14:19-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314148931,"product_id":8590647747,"name":"Title","position":1,"values":["SKU-17"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592445059,"title":"Product #3 - 6629","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T16:24:07-04:00","handle":"product-3-6629","updated_at":"2016-09-23T16:24:07-04:00","published_at":"2015-09-23T16:24:06-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28635724931,"product_id":8592445059,"title":"Default
+        Title","price":"0.00","sku":"","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"Default
+        Title","option2":null,"option3":null,"created_at":"2016-09-23T16:24:07-04:00","updated_at":"2016-09-23T16:24:07-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"kg","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316544067,"product_id":8592445059,"name":"Title","position":1,"values":["Default
+        Title"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:19 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590647747.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590647747,"title":"Product #6 - 6452","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:18.699Z","handle":"product-6-6452","updated_at":"2016-09-23T18:14:18.720Z","published_at":"2015-09-23T18:14:18.663Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631128003,"title":"SKU-17","price":"19.99","sku":"SKU-17","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-17","option2":null,"option3":null,"created_at":"2016-09-23T14:14:19-04:00","updated_at":"2016-09-23T14:14:19-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314148931,"product_id":8590647747,"name":"Title","position":1,"values":["SKU-17"]}],"images":[{"variant_ids":["28631128003"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:20 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590647747
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/418ba7c8-56f1-43c7-9268-82fed133cfc0?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 418ba7c8-56f1-43c7-9268-82fed133cfc0
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590647747,"title":"Product #6 - 6452","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:19-04:00","handle":"product-6-6452","updated_at":"2016-09-23T14:14:20-04:00","published_at":"2015-09-23T14:14:18-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631128003,"product_id":8590647747,"title":"SKU-17","price":"19.99","sku":"SKU-17","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-17","option2":null,"option3":null,"created_at":"2016-09-23T14:14:19-04:00","updated_at":"2016-09-23T14:14:19-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314148931,"product_id":8590647747,"name":"Title","position":1,"values":["SKU-17"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:20 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:20 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/0e1282c6-d5ba-41ff-b7a7-519bf64a8d40?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 0e1282c6-d5ba-41ff-b7a7-519bf64a8d40
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:20 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #7 - 5784","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:20.522Z","updated_at":"2016-09-23T18:14:20.548Z","published_at":"2015-09-23T18:14:20.509Z","vendor":"Default
-        Vendor","handle":"product-7-5784","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-18","inventory_management":"shopify","updated_at":"2016-09-23T18:14:20.543Z","option1":"SKU-18"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:21 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590648515
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/11cc242f-5aef-4e2b-a629-1e5c00042c90?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 11cc242f-5aef-4e2b-a629-1e5c00042c90
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590648515,"title":"Product #7 - 5784","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:20-04:00","handle":"product-7-5784","updated_at":"2016-09-23T14:14:20-04:00","published_at":"2015-09-23T14:14:20-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631130115,"product_id":8590648515,"title":"SKU-18","price":"19.99","sku":"SKU-18","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-18","option2":null,"option3":null,"created_at":"2016-09-23T14:14:20-04:00","updated_at":"2016-09-23T14:14:20-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314149891,"product_id":8590648515,"name":"Title","position":1,"values":["SKU-18"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:21 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590648515.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:21 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/f45f27d3-4fbb-44e9-bc24-61bf95f3ac80?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - f45f27d3-4fbb-44e9-bc24-61bf95f3ac80
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590648515,"title":"Product #7 - 5784","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:20-04:00","handle":"product-7-5784","updated_at":"2016-09-23T14:14:20-04:00","published_at":"2015-09-23T14:14:20-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631130115,"product_id":8590648515,"title":"SKU-18","price":"19.99","sku":"SKU-18","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-18","option2":null,"option3":null,"created_at":"2016-09-23T14:14:20-04:00","updated_at":"2016-09-23T14:14:20-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314149891,"product_id":8590648515,"name":"Title","position":1,"values":["SKU-18"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:21 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590648515.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590648515,"title":"Product #7 - 5784","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:20.522Z","handle":"product-7-5784","updated_at":"2016-09-23T18:14:20.548Z","published_at":"2015-09-23T18:14:20.509Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631130115,"title":"SKU-18","price":"19.99","sku":"SKU-18","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-18","option2":null,"option3":null,"created_at":"2016-09-23T14:14:20-04:00","updated_at":"2016-09-23T14:14:20-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314149891,"product_id":8590648515,"name":"Title","position":1,"values":["SKU-18"]}],"images":[{"variant_ids":["28631130115"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:21 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590648515
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/6f0b33f2-0c80-497b-b1ef-fdd739f29f40?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 6f0b33f2-0c80-497b-b1ef-fdd739f29f40
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590648515,"title":"Product #7 - 5784","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:20-04:00","handle":"product-7-5784","updated_at":"2016-09-23T14:14:21-04:00","published_at":"2015-09-23T14:14:20-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631130115,"product_id":8590648515,"title":"SKU-18","price":"19.99","sku":"SKU-18","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-18","option2":null,"option3":null,"created_at":"2016-09-23T14:14:20-04:00","updated_at":"2016-09-23T14:14:20-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314149891,"product_id":8590648515,"name":"Title","position":1,"values":["SKU-18"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:21 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:22 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/7ffe1a2c-cf7e-44cd-a161-cb81e63e1df9?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 7ffe1a2c-cf7e-44cd-a161-cb81e63e1df9
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:22 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #8 - 4149","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:22.087Z","updated_at":"2016-09-23T18:14:22.114Z","published_at":"2015-09-23T18:14:22.074Z","vendor":"Default
-        Vendor","handle":"product-8-4149","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-19","inventory_management":"shopify","updated_at":"2016-09-23T18:14:22.108Z","option1":"SKU-19"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:22 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590649027
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/9bf3ce2f-0f80-4c9c-bac7-663eaa8cb30b?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 9bf3ce2f-0f80-4c9c-bac7-663eaa8cb30b
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590649027,"title":"Product #8 - 4149","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:22-04:00","handle":"product-8-4149","updated_at":"2016-09-23T14:14:22-04:00","published_at":"2015-09-23T14:14:22-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631130947,"product_id":8590649027,"title":"SKU-19","price":"19.99","sku":"SKU-19","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-19","option2":null,"option3":null,"created_at":"2016-09-23T14:14:22-04:00","updated_at":"2016-09-23T14:14:22-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314150531,"product_id":8590649027,"name":"Title","position":1,"values":["SKU-19"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:22 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590649027.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:22 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/8b3bbd74-b509-40b0-8050-f6250a8a011d?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 8b3bbd74-b509-40b0-8050-f6250a8a011d
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590649027,"title":"Product #8 - 4149","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:22-04:00","handle":"product-8-4149","updated_at":"2016-09-23T14:14:22-04:00","published_at":"2015-09-23T14:14:22-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631130947,"product_id":8590649027,"title":"SKU-19","price":"19.99","sku":"SKU-19","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-19","option2":null,"option3":null,"created_at":"2016-09-23T14:14:22-04:00","updated_at":"2016-09-23T14:14:22-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314150531,"product_id":8590649027,"name":"Title","position":1,"values":["SKU-19"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:22 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590649027.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590649027,"title":"Product #8 - 4149","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:22.087Z","handle":"product-8-4149","updated_at":"2016-09-23T18:14:22.114Z","published_at":"2015-09-23T18:14:22.074Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631130947,"title":"SKU-19","price":"19.99","sku":"SKU-19","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-19","option2":null,"option3":null,"created_at":"2016-09-23T14:14:22-04:00","updated_at":"2016-09-23T14:14:22-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314150531,"product_id":8590649027,"name":"Title","position":1,"values":["SKU-19"]}],"images":[{"variant_ids":["28631130947"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:23 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590649027
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/4760179b-c3dc-4c37-a273-8708f8a254c3?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 4760179b-c3dc-4c37-a273-8708f8a254c3
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590649027,"title":"Product #8 - 4149","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:22-04:00","handle":"product-8-4149","updated_at":"2016-09-23T14:14:23-04:00","published_at":"2015-09-23T14:14:22-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631130947,"product_id":8590649027,"title":"SKU-19","price":"19.99","sku":"SKU-19","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-19","option2":null,"option3":null,"created_at":"2016-09-23T14:14:22-04:00","updated_at":"2016-09-23T14:14:22-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314150531,"product_id":8590649027,"name":"Title","position":1,"values":["SKU-19"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:23 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:23 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/cd15ccb2-6851-48ec-9b55-b5bf95d63079?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - cd15ccb2-6851-48ec-9b55-b5bf95d63079
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:23 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #9 - 1952","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:23.474Z","updated_at":"2016-09-23T18:14:23.522Z","published_at":"2015-09-23T18:14:23.463Z","vendor":"Default
-        Vendor","handle":"product-9-1952","options":[{"name":"foo-size-7"},{"name":"foo-size-8"},{"name":"foo-size-9"}],"variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKUS-M/SKUS-1/SKUS-2/SKUS-3","updated_at":"2016-09-23T18:14:23.520Z","option1":"S","option2":"S","option3":"S"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:24 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590649667
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/2c0e0147-e59e-4c2d-b000-80923776ef94?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 2c0e0147-e59e-4c2d-b000-80923776ef94
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590649667,"title":"Product #9 - 1952","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:23-04:00","handle":"product-9-1952","updated_at":"2016-09-23T14:14:24-04:00","published_at":"2015-09-23T14:14:23-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631132035,"product_id":8590649667,"title":"S
-        \/ S \/ S","price":"19.99","sku":"SKUS-M\/SKUS-1\/SKUS-2\/SKUS-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"S","option2":"S","option3":"S","created_at":"2016-09-23T14:14:24-04:00","updated_at":"2016-09-23T14:14:24-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314151299,"product_id":8590649667,"name":"foo-size-7","position":1,"values":["S"]},{"id":10314151363,"product_id":8590649667,"name":"foo-size-8","position":2,"values":["S"]},{"id":10314151427,"product_id":8590649667,"name":"foo-size-9","position":3,"values":["S"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:24 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590649667.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:24 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/46f5772a-7ce7-445f-a1fd-1faddbcc8fe0?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 46f5772a-7ce7-445f-a1fd-1faddbcc8fe0
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590649667,"title":"Product #9 - 1952","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:23-04:00","handle":"product-9-1952","updated_at":"2016-09-23T14:14:24-04:00","published_at":"2015-09-23T14:14:23-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631132035,"product_id":8590649667,"title":"S
-        \/ S \/ S","price":"19.99","sku":"SKUS-M\/SKUS-1\/SKUS-2\/SKUS-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"S","option2":"S","option3":"S","created_at":"2016-09-23T14:14:24-04:00","updated_at":"2016-09-23T14:14:24-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314151299,"product_id":8590649667,"name":"foo-size-7","position":1,"values":["S"]},{"id":10314151363,"product_id":8590649667,"name":"foo-size-8","position":2,"values":["S"]},{"id":10314151427,"product_id":8590649667,"name":"foo-size-9","position":3,"values":["S"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:24 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:08 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590649667.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592445059.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1075,7 +236,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:25 GMT
+      - Fri, 23 Sep 2016 20:24:09 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -1091,9 +252,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 28/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 28/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -1103,9 +264,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e63d8600-c521-4545-b387-6cb4f1b13a90?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/47212174-4b5e-42de-803e-4ec67fb9441a?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - e63d8600-c521-4545-b387-6cb4f1b13a90
+      - 47212174-4b5e-42de-803e-4ec67fb9441a
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -1121,5 +282,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:25 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Export_a_bundled_Spree_product_with_its_assembly_on_Shopify/creates_a_bundled_product.yml
+++ b/spec/cassettes/Export_a_bundled_Spree_product_with_its_assembly_on_Shopify/creates_a_bundled_product.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:38 GMT
+      - Fri, 23 Sep 2016 20:24:09 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 32/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 32/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/3a46d51b-f599-4efc-98ce-b6807e6c0b40?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/410f34e7-8e24-4296-899b-055983ef422a?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 3a46d51b-f599-4efc-98ce-b6807e6c0b40
+      - 410f34e7-8e24-4296-899b-055983ef422a
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:38 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:09 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
-      string: '{"product":{"title":"Product #18 - 4484","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:38.627Z","updated_at":"2016-09-23T18:14:38.660Z","published_at":"2015-09-23T18:14:38.589Z","vendor":"Default
-        Vendor","handle":"product-18-4484","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-29","inventory_management":"shopify","updated_at":"2016-09-23T18:14:38.647Z","option1":"SKU-29"}]}}'
+      string: '{"product":{"title":"Product #4 - 2301","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T20:24:09.271Z","updated_at":"2016-09-23T20:24:09.296Z","published_at":"2015-09-23T20:24:09.246Z","vendor":"Default
+        Vendor","handle":"product-4-2301","options":[],"variants":[]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:39 GMT
+      - Fri, 23 Sep 2016 20:24:09 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 33/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 33/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590654403
+      - https://glossier-pop-staging.myshopify.com/admin/products/8592445507
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/4bcb937d-66d6-40f1-b40f-1e40400a9ef8?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/811a2f7b-1b32-47f9-bcc8-d574660ce7cc?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 4bcb937d-66d6-40f1-b40f-1e40400a9ef8
+      - 811a2f7b-1b32-47f9-bcc8-d574660ce7cc
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,16 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590654403,"title":"Product #18 - 4484","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:38-04:00","handle":"product-18-4484","updated_at":"2016-09-23T14:14:39-04:00","published_at":"2015-09-23T14:14:38-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631143683,"product_id":8590654403,"title":"SKU-29","price":"19.99","sku":"SKU-29","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-29","option2":null,"option3":null,"created_at":"2016-09-23T14:14:39-04:00","updated_at":"2016-09-23T14:14:39-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314156931,"product_id":8590654403,"name":"Title","position":1,"values":["SKU-29"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592445507,"title":"Product #4 - 2301","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T16:24:09-04:00","handle":"product-4-2301","updated_at":"2016-09-23T16:24:09-04:00","published_at":"2015-09-23T16:24:09-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28635725635,"product_id":8592445507,"title":"Default
+        Title","price":"0.00","sku":"","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"Default
+        Title","option2":null,"option3":null,"created_at":"2016-09-23T16:24:09-04:00","updated_at":"2016-09-23T16:24:09-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"kg","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316544835,"product_id":8592445507,"name":"Title","position":1,"values":["Default
+        Title"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:39 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:10 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590654403.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592445507.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +164,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:39 GMT
+      - Fri, 23 Sep 2016 20:24:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +180,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 33/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 33/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +190,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/5f4bace5-5eb0-4353-ad2c-9bf22d1b08c1?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/de6e8964-2b1a-499a-a802-8a26350312be?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 5f4bace5-5eb0-4353-ad2c-9bf22d1b08c1
+      - de6e8964-2b1a-499a-a802-8a26350312be
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,858 +206,16 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590654403,"title":"Product #18 - 4484","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:38-04:00","handle":"product-18-4484","updated_at":"2016-09-23T14:14:39-04:00","published_at":"2015-09-23T14:14:38-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631143683,"product_id":8590654403,"title":"SKU-29","price":"19.99","sku":"SKU-29","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-29","option2":null,"option3":null,"created_at":"2016-09-23T14:14:39-04:00","updated_at":"2016-09-23T14:14:39-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314156931,"product_id":8590654403,"name":"Title","position":1,"values":["SKU-29"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592445507,"title":"Product #4 - 2301","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T16:24:09-04:00","handle":"product-4-2301","updated_at":"2016-09-23T16:24:09-04:00","published_at":"2015-09-23T16:24:09-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28635725635,"product_id":8592445507,"title":"Default
+        Title","price":"0.00","sku":"","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"Default
+        Title","option2":null,"option3":null,"created_at":"2016-09-23T16:24:09-04:00","updated_at":"2016-09-23T16:24:09-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"kg","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316544835,"product_id":8592445507,"name":"Title","position":1,"values":["Default
+        Title"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:39 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590654403.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590654403,"title":"Product #18 - 4484","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:38.627Z","handle":"product-18-4484","updated_at":"2016-09-23T18:14:38.660Z","published_at":"2015-09-23T18:14:38.589Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631143683,"title":"SKU-29","price":"19.99","sku":"SKU-29","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-29","option2":null,"option3":null,"created_at":"2016-09-23T14:14:39-04:00","updated_at":"2016-09-23T14:14:39-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314156931,"product_id":8590654403,"name":"Title","position":1,"values":["SKU-29"]}],"images":[{"variant_ids":["28631143683"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:39 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 33/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 33/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590654403
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/010e9405-d773-425a-b9db-0661ea9ac6e0?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 010e9405-d773-425a-b9db-0661ea9ac6e0
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590654403,"title":"Product #18 - 4484","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:38-04:00","handle":"product-18-4484","updated_at":"2016-09-23T14:14:39-04:00","published_at":"2015-09-23T14:14:38-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631143683,"product_id":8590654403,"title":"SKU-29","price":"19.99","sku":"SKU-29","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-29","option2":null,"option3":null,"created_at":"2016-09-23T14:14:39-04:00","updated_at":"2016-09-23T14:14:39-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314156931,"product_id":8590654403,"name":"Title","position":1,"values":["SKU-29"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:39 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:40 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 33/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 33/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c1c74b6c-a9d2-475a-a04b-0dc8f19fc82e?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - c1c74b6c-a9d2-475a-a04b-0dc8f19fc82e
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:40 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #19 - 8235","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:40.043Z","updated_at":"2016-09-23T18:14:40.068Z","published_at":"2015-09-23T18:14:40.030Z","vendor":"Default
-        Vendor","handle":"product-19-8235","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-30","inventory_management":"shopify","updated_at":"2016-09-23T18:14:40.062Z","option1":"SKU-30"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:40 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 34/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 34/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590654787
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ee408ed1-9e2b-4057-8162-7a61d2786f4b?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - ee408ed1-9e2b-4057-8162-7a61d2786f4b
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590654787,"title":"Product #19 - 8235","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:40-04:00","handle":"product-19-8235","updated_at":"2016-09-23T14:14:40-04:00","published_at":"2015-09-23T14:14:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631144643,"product_id":8590654787,"title":"SKU-30","price":"19.99","sku":"SKU-30","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-30","option2":null,"option3":null,"created_at":"2016-09-23T14:14:40-04:00","updated_at":"2016-09-23T14:14:40-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314157443,"product_id":8590654787,"name":"Title","position":1,"values":["SKU-30"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:41 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590654787.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:41 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 34/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 34/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/4f9734f8-875f-4da0-8f32-5a78b5681d88?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 4f9734f8-875f-4da0-8f32-5a78b5681d88
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590654787,"title":"Product #19 - 8235","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:40-04:00","handle":"product-19-8235","updated_at":"2016-09-23T14:14:40-04:00","published_at":"2015-09-23T14:14:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631144643,"product_id":8590654787,"title":"SKU-30","price":"19.99","sku":"SKU-30","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-30","option2":null,"option3":null,"created_at":"2016-09-23T14:14:40-04:00","updated_at":"2016-09-23T14:14:40-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314157443,"product_id":8590654787,"name":"Title","position":1,"values":["SKU-30"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:41 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590654787.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590654787,"title":"Product #19 - 8235","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:40.043Z","handle":"product-19-8235","updated_at":"2016-09-23T18:14:40.068Z","published_at":"2015-09-23T18:14:40.030Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631144643,"title":"SKU-30","price":"19.99","sku":"SKU-30","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-30","option2":null,"option3":null,"created_at":"2016-09-23T14:14:40-04:00","updated_at":"2016-09-23T14:14:40-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314157443,"product_id":8590654787,"name":"Title","position":1,"values":["SKU-30"]}],"images":[{"variant_ids":["28631144643"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:41 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 34/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 34/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590654787
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/7ad0b4b6-614e-4af6-8a0f-95b5eae402f6?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 7ad0b4b6-614e-4af6-8a0f-95b5eae402f6
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590654787,"title":"Product #19 - 8235","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:40-04:00","handle":"product-19-8235","updated_at":"2016-09-23T14:14:41-04:00","published_at":"2015-09-23T14:14:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631144643,"product_id":8590654787,"title":"SKU-30","price":"19.99","sku":"SKU-30","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-30","option2":null,"option3":null,"created_at":"2016-09-23T14:14:40-04:00","updated_at":"2016-09-23T14:14:40-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314157443,"product_id":8590654787,"name":"Title","position":1,"values":["SKU-30"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:41 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:42 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 34/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 34/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ccb73d97-01a0-4096-886a-43498af430c1?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - ccb73d97-01a0-4096-886a-43498af430c1
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:42 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #20 - 7162","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:41.711Z","updated_at":"2016-09-23T18:14:41.738Z","published_at":"2015-09-23T18:14:41.699Z","vendor":"Default
-        Vendor","handle":"product-20-7162","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-31","inventory_management":"shopify","updated_at":"2016-09-23T18:14:41.732Z","option1":"SKU-31"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:42 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590655299
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e93ea1c1-dd52-47d4-9414-9bb386e6271e?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - e93ea1c1-dd52-47d4-9414-9bb386e6271e
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590655299,"title":"Product #20 - 7162","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:42-04:00","handle":"product-20-7162","updated_at":"2016-09-23T14:14:42-04:00","published_at":"2015-09-23T14:14:41-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631145731,"product_id":8590655299,"title":"SKU-31","price":"19.99","sku":"SKU-31","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-31","option2":null,"option3":null,"created_at":"2016-09-23T14:14:42-04:00","updated_at":"2016-09-23T14:14:42-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314158083,"product_id":8590655299,"name":"Title","position":1,"values":["SKU-31"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:42 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590655299.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:42 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c283b62c-660e-493e-9794-dbae7b21a16f?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - c283b62c-660e-493e-9794-dbae7b21a16f
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590655299,"title":"Product #20 - 7162","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:42-04:00","handle":"product-20-7162","updated_at":"2016-09-23T14:14:42-04:00","published_at":"2015-09-23T14:14:41-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631145731,"product_id":8590655299,"title":"SKU-31","price":"19.99","sku":"SKU-31","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-31","option2":null,"option3":null,"created_at":"2016-09-23T14:14:42-04:00","updated_at":"2016-09-23T14:14:42-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314158083,"product_id":8590655299,"name":"Title","position":1,"values":["SKU-31"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:42 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590655299.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590655299,"title":"Product #20 - 7162","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:41.711Z","handle":"product-20-7162","updated_at":"2016-09-23T18:14:41.738Z","published_at":"2015-09-23T18:14:41.699Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631145731,"title":"SKU-31","price":"19.99","sku":"SKU-31","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-31","option2":null,"option3":null,"created_at":"2016-09-23T14:14:42-04:00","updated_at":"2016-09-23T14:14:42-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314158083,"product_id":8590655299,"name":"Title","position":1,"values":["SKU-31"]}],"images":[{"variant_ids":["28631145731"],"attachment":null}],"image":null}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:43 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590655299
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/0ca9ac5e-99bd-4ebb-aee4-ba4458fc3a9e?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 0ca9ac5e-99bd-4ebb-aee4-ba4458fc3a9e
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590655299,"title":"Product #20 - 7162","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:42-04:00","handle":"product-20-7162","updated_at":"2016-09-23T14:14:42-04:00","published_at":"2015-09-23T14:14:41-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631145731,"product_id":8590655299,"title":"SKU-31","price":"19.99","sku":"SKU-31","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-31","option2":null,"option3":null,"created_at":"2016-09-23T14:14:42-04:00","updated_at":"2016-09-23T14:14:42-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314158083,"product_id":8590655299,"name":"Title","position":1,"values":["SKU-31"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:43 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:43 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 35/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/fdd9ea15-babe-403d-9e40-10f6fd372716?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
-      X-Request-Id:
-      - fdd9ea15-babe-403d-9e40-10f6fd372716
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"errors":"Not Found"}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:43 GMT
-- request:
-    method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products.json
-    body:
-      encoding: UTF-8
-      string: '{"product":{"title":"Product #21 - 9708","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:43.284Z","updated_at":"2016-09-23T18:14:43.334Z","published_at":"2015-09-23T18:14:43.267Z","vendor":"Default
-        Vendor","handle":"product-21-9708","options":[{"name":"foo-size-16"},{"name":"foo-size-17"},{"name":"foo-size-18"}],"variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKUS-M/SKUS-1/SKUS-2/SKUS-3","updated_at":"2016-09-23T18:14:43.332Z","option1":"S","option2":"S","option3":"S"}]}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:44 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590655747
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/3e148c97-4352-4aea-9d66-2df57745b7d1?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 3e148c97-4352-4aea-9d66-2df57745b7d1
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"product":{"id":8590655747,"title":"Product #21 - 9708","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:43-04:00","handle":"product-21-9708","updated_at":"2016-09-23T14:14:43-04:00","published_at":"2015-09-23T14:14:43-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631146691,"product_id":8590655747,"title":"S
-        \/ S \/ S","price":"19.99","sku":"SKUS-M\/SKUS-1\/SKUS-2\/SKUS-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"S","option2":"S","option3":"S","created_at":"2016-09-23T14:14:43-04:00","updated_at":"2016-09-23T14:14:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314158659,"product_id":8590655747,"name":"foo-size-16","position":1,"values":["S"]},{"id":10314158723,"product_id":8590655747,"name":"foo-size-17","position":2,"values":["S"]},{"id":10314158787,"product_id":8590655747,"name":"foo-size-18","position":3,"values":["S"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:44 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590655747.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:14:44 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1ee57c64-e77c-4d14-8b13-20337c140d81?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 1ee57c64-e77c-4d14-8b13-20337c140d81
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"product":{"id":8590655747,"title":"Product #21 - 9708","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:43-04:00","handle":"product-21-9708","updated_at":"2016-09-23T14:14:43-04:00","published_at":"2015-09-23T14:14:43-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631146691,"product_id":8590655747,"title":"S
-        \/ S \/ S","price":"19.99","sku":"SKUS-M\/SKUS-1\/SKUS-2\/SKUS-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":null,"option1":"S","option2":"S","option3":"S","created_at":"2016-09-23T14:14:43-04:00","updated_at":"2016-09-23T14:14:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314158659,"product_id":8590655747,"name":"foo-size-16","position":1,"values":["S"]},{"id":10314158723,"product_id":8590655747,"name":"foo-size-17","position":2,"values":["S"]},{"id":10314158787,"product_id":8590655747,"name":"foo-size-18","position":3,"values":["S"]}],"images":[],"image":null}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:44 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:10 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590655747.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592445507.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1075,7 +236,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:44 GMT
+      - Fri, 23 Sep 2016 20:24:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -1091,9 +252,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 36/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -1103,9 +264,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/3c9a97d1-ec75-41ac-adec-7239b9dcee60?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/1324badf-5f24-4976-8134-ce14ecb8c5af?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 3c9a97d1-ec75-41ac-adec-7239b9dcee60
+      - 1324badf-5f24-4976-8134-ce14ecb8c5af
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -1121,5 +282,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:44 GMT
+  recorded_at: Fri, 23 Sep 2016 20:24:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Refund_a_Shopify_order_on_Glossier/that_is_partially_fulfilled/is_refunding_the_order_on_Shopify.yml
+++ b/spec/cassettes/Refund_a_Shopify_order_on_Glossier/that_is_partially_fulfilled/is_refunding_the_order_on_Shopify.yml
@@ -29,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:55 GMT
+      - Fri, 23 Sep 2016 19:47:18 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -43,9 +43,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 20/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 20/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -53,11 +53,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/orders/3796739523
+      - https://glossier-pop-staging.myshopify.com/admin/orders/3797376259
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/470aec3b-35f8-42a0-81c4-25efe741356e?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/6ea7189e-6456-4339-8de3-71dfaa6cd005?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
       X-Request-Id:
-      - 470aec3b-35f8-42a0-81c4-25efe741356e
+      - 6ea7189e-6456-4339-8de3-71dfaa6cd005
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -71,18 +71,18 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"order":{"id":3796739523,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T14:13:54-04:00","updated_at":"2016-09-23T14:13:55-04:00","number":394,"note":null,"token":"b3de71d12eea0055f44841df5e7cb5e3","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"paid","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1394","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T14:13:54-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1394,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7009113603,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
+      string: '{"order":{"id":3797376259,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T15:47:17-04:00","updated_at":"2016-09-23T15:47:18-04:00","number":399,"note":null,"token":"75708808c232569730e2d245f1d269da","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"paid","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1399","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T15:47:17-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1399,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7010410755,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
         Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
         Smith","country_code":"CA","province_code":"ON"},"shipping_address":{"first_name":"John","address1":"123
         Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
-        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3106985475,"order_id":3796739523,"status":"success","created_at":"2016-09-23T14:13:55-04:00","service":"manual","updated_at":"2016-09-23T14:13:55-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7009113603,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T14:13:55-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3796739523,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1394","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
+        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3107715587,"order_id":3797376259,"status":"success","created_at":"2016-09-23T15:47:18-04:00","service":"manual","updated_at":"2016-09-23T15:47:18-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7010410755,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T15:47:18-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3797376259,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1399","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
         Fake Street","address2":null,"city":"Fakecity","province":"Ontario","country":"Canada","zip":"K2P
         1L4","phone":"555-555-5555","name":"John Smith","province_code":"ON","country_code":"CA","country_name":"Canada","default":true}}}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:55 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:18 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796739523.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797376259.json
     body:
       encoding: US-ASCII
       string: ''
@@ -103,7 +103,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:56 GMT
+      - Fri, 23 Sep 2016 19:47:18 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -119,9 +119,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -129,9 +129,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ee6a4e1c-0ff6-4076-ba3b-1cd949a5b1bb?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/0802d90e-1dee-4409-8eae-65124502bb29?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
       X-Request-Id:
-      - ee6a4e1c-0ff6-4076-ba3b-1cd949a5b1bb
+      - 0802d90e-1dee-4409-8eae-65124502bb29
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -145,18 +145,18 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"order":{"id":3796739523,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T14:13:54-04:00","updated_at":"2016-09-23T14:13:55-04:00","number":394,"note":null,"token":"b3de71d12eea0055f44841df5e7cb5e3","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"paid","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1394","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T14:13:54-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1394,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7009113603,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
-        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":45.4203521,"longitude":-75.69314750000001,"name":"John
+      string: '{"order":{"id":3797376259,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T15:47:17-04:00","updated_at":"2016-09-23T15:47:18-04:00","number":399,"note":null,"token":"75708808c232569730e2d245f1d269da","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"paid","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1399","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T15:47:17-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1399,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7010410755,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
+        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
         Smith","country_code":"CA","province_code":"ON"},"shipping_address":{"first_name":"John","address1":"123
-        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":45.4203521,"longitude":-75.69314750000001,"name":"John
-        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3106985475,"order_id":3796739523,"status":"success","created_at":"2016-09-23T14:13:55-04:00","service":"manual","updated_at":"2016-09-23T14:13:55-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7009113603,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T14:13:55-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3796739523,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1394","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
+        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
+        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3107715587,"order_id":3797376259,"status":"success","created_at":"2016-09-23T15:47:18-04:00","service":"manual","updated_at":"2016-09-23T15:47:18-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7010410755,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T15:47:18-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3797376259,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1399","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
         Fake Street","address2":null,"city":"Fakecity","province":"Ontario","country":"Canada","zip":"K2P
         1L4","phone":"555-555-5555","name":"John Smith","province_code":"ON","country_code":"CA","country_name":"Canada","default":true}}}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:56 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:19 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796739523/transactions.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797376259/transactions.json
     body:
       encoding: US-ASCII
       string: ''
@@ -177,7 +177,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:56 GMT
+      - Fri, 23 Sep 2016 19:47:19 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -193,9 +193,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 18/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 18/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -203,9 +203,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d79be7c0-78ee-4838-aff1-f58f615772ae?source%5Baction%5D=index&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/999df4a7-4caa-4271-b1a5-c08829281efe?source%5Baction%5D=index&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin
       X-Request-Id:
-      - d79be7c0-78ee-4838-aff1-f58f615772ae
+      - 999df4a7-4caa-4271-b1a5-c08829281efe
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -219,12 +219,12 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"transactions":[{"id":4145770819,"order_id":3796739523,"amount":"100.00","kind":"capture","gateway":"","status":"success","message":null,"created_at":"2016-09-23T14:13:54-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":null,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}]}'
+      string: '{"transactions":[{"id":4146564611,"order_id":3797376259,"amount":"100.00","kind":"capture","gateway":"","status":"success","message":null,"created_at":"2016-09-23T15:47:17-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":null,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}]}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:56 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:19 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796739523/transactions/4145770819.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797376259/transactions/4146564611.json
     body:
       encoding: US-ASCII
       string: ''
@@ -245,7 +245,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:56 GMT
+      - Fri, 23 Sep 2016 19:47:19 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -261,9 +261,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -271,9 +271,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/beba9bbf-3eeb-468a-8213-02a52ce0143d?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/993d443b-5683-48db-a01e-a72848438cf3?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Ftransactions&source%5Bsection%5D=admin
       X-Request-Id:
-      - beba9bbf-3eeb-468a-8213-02a52ce0143d
+      - 993d443b-5683-48db-a01e-a72848438cf3
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -287,15 +287,15 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"transaction":{"id":4145770819,"order_id":3796739523,"amount":"100.00","kind":"capture","gateway":"","status":"success","message":null,"created_at":"2016-09-23T14:13:54-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":null,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}}'
+      string: '{"transaction":{"id":4146564611,"order_id":3797376259,"amount":"100.00","kind":"capture","gateway":"","status":"success","message":null,"created_at":"2016-09-23T15:47:17-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":null,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:56 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:19 GMT
 - request:
     method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796739523/refunds.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797376259/refunds.json
     body:
       encoding: UTF-8
-      string: '{"refund":{"shipping":{"amount":0},"note":null,"notify":false,"restock":false,"transactions":[{"parent_id":4145770819,"amount":"100.0","gateway":"shopify-payments","kind":"refund"}]}}'
+      string: '{"refund":{"shipping":{"amount":0},"note":null,"notify":false,"restock":false,"transactions":[{"parent_id":4146564611,"amount":"100.0","gateway":"shopify-payments","kind":"refund"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -315,7 +315,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:57 GMT
+      - Fri, 23 Sep 2016 19:47:20 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -329,9 +329,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -339,11 +339,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/orders/3796739523/refunds/142907587
+      - https://glossier-pop-staging.myshopify.com/admin/orders/3797376259/refunds/142946243
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d9a334c9-d3fb-4832-bcff-92c0e41d9d55?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Frefunds&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/5a82db7d-904c-46c2-9e63-244d7c4b8648?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Frefunds&source%5Bsection%5D=admin
       X-Request-Id:
-      - d9a334c9-d3fb-4832-bcff-92c0e41d9d55
+      - 5a82db7d-904c-46c2-9e63-244d7c4b8648
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -357,14 +357,14 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"refund":{"id":142907587,"order_id":3796739523,"created_at":"2016-09-23T14:13:56-04:00","note":null,"restock":false,"user_id":0,"refund_line_items":[],"transactions":[{"id":4145771139,"order_id":3796739523,"amount":"100.00","kind":"refund","gateway":"","status":"success","message":"Refunded
-        100.00 from manual gateway","created_at":"2016-09-23T14:13:56-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":4145770819,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}],"order_adjustments":[{"id":103549891,"order_id":3796739523,"refund_id":142907587,"amount":"-100.00","tax_amount":"0.00","kind":"refund_discrepancy","reason":"Refund
+      string: '{"refund":{"id":142946243,"order_id":3797376259,"created_at":"2016-09-23T15:47:20-04:00","note":null,"restock":false,"user_id":0,"refund_line_items":[],"transactions":[{"id":4146564995,"order_id":3797376259,"amount":"100.00","kind":"refund","gateway":"","status":"success","message":"Refunded
+        100.00 from manual gateway","created_at":"2016-09-23T15:47:20-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":4146564611,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}],"order_adjustments":[{"id":103566275,"order_id":3797376259,"refund_id":142946243,"amount":"-100.00","tax_amount":"0.00","kind":"refund_discrepancy","reason":"Refund
         discrepancy"}]}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:57 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:20 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796739523.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797376259.json
     body:
       encoding: US-ASCII
       string: ''
@@ -385,7 +385,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:57 GMT
+      - Fri, 23 Sep 2016 19:47:20 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -401,9 +401,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -411,9 +411,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/f1df81e5-7704-42fc-82ab-526ec5391784?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/33c69e91-b739-481e-bd19-e6d0395fc63a?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
       X-Request-Id:
-      - f1df81e5-7704-42fc-82ab-526ec5391784
+      - 33c69e91-b739-481e-bd19-e6d0395fc63a
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -427,20 +427,20 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"order":{"id":3796739523,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T14:13:54-04:00","updated_at":"2016-09-23T14:13:56-04:00","number":394,"note":null,"token":"b3de71d12eea0055f44841df5e7cb5e3","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"refunded","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1394","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T14:13:54-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1394,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7009113603,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
-        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":45.4203521,"longitude":-75.69314750000001,"name":"John
+      string: '{"order":{"id":3797376259,"email":"cab@godynamo.com","closed_at":null,"created_at":"2016-09-23T15:47:17-04:00","updated_at":"2016-09-23T15:47:20-04:00","number":399,"note":null,"token":"75708808c232569730e2d245f1d269da","gateway":"","test":false,"total_price":"100.00","subtotal_price":"100.00","total_weight":0,"total_tax":"0.00","taxes_included":false,"currency":"CAD","financial_status":"refunded","confirmed":true,"total_discounts":"0.00","total_line_items_price":"100.00","cart_token":null,"buyer_accepts_marketing":false,"name":"#1399","referring_site":null,"landing_site":null,"cancelled_at":null,"cancel_reason":null,"total_price_usd":"76.64","checkout_token":null,"reference":null,"user_id":null,"location_id":null,"source_identifier":null,"source_url":null,"processed_at":"2016-09-23T15:47:17-04:00","device_id":null,"browser_ip":null,"landing_site_ref":null,"order_number":1399,"discount_codes":[],"note_attributes":[],"payment_gateway_names":[""],"processing_method":"","checkout_id":null,"source_name":"1413328","fulfillment_status":"fulfilled","tax_lines":[],"tags":"","contact_email":"cab@godynamo.com","order_status_url":null,"line_items":[{"id":7010410755,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}],"shipping_lines":[],"billing_address":{"first_name":"John","address1":"123
+        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
         Smith","country_code":"CA","province_code":"ON"},"shipping_address":{"first_name":"John","address1":"123
-        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":45.4203521,"longitude":-75.69314750000001,"name":"John
-        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3106985475,"order_id":3796739523,"status":"success","created_at":"2016-09-23T14:13:55-04:00","service":"manual","updated_at":"2016-09-23T14:13:55-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7009113603,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[{"id":142907587,"order_id":3796739523,"created_at":"2016-09-23T14:13:56-04:00","note":null,"restock":false,"user_id":0,"refund_line_items":[],"transactions":[{"id":4145771139,"order_id":3796739523,"amount":"100.00","kind":"refund","gateway":"","status":"success","message":"Refunded
-        100.00 from manual gateway","created_at":"2016-09-23T14:13:56-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":4145770819,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}],"order_adjustments":[{"id":103549891,"order_id":3796739523,"refund_id":142907587,"amount":"-100.00","tax_amount":"0.00","kind":"refund_discrepancy","reason":"Refund
-        discrepancy"}]}],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T14:13:57-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"300.00","last_order_id":3796739523,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1394","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
+        Fake Street","phone":"555-555-5555","city":"Fakecity","zip":"K2P 1L4","province":"Ontario","country":"Canada","last_name":"Smith","address2":null,"company":null,"latitude":null,"longitude":null,"name":"John
+        Smith","country_code":"CA","province_code":"ON"},"fulfillments":[{"id":3107715587,"order_id":3797376259,"status":"success","created_at":"2016-09-23T15:47:18-04:00","service":"manual","updated_at":"2016-09-23T15:47:18-04:00","tracking_company":null,"shipment_status":null,"tracking_number":null,"tracking_numbers":[],"tracking_url":null,"tracking_urls":[],"receipt":{},"line_items":[{"id":7010410755,"variant_id":null,"title":"title","quantity":1,"price":"100.00","grams":0,"sku":null,"variant_title":null,"vendor":null,"fulfillment_service":"manual","product_id":null,"requires_shipping":true,"taxable":true,"gift_card":false,"name":"title","variant_inventory_management":null,"properties":[],"product_exists":false,"fulfillable_quantity":0,"total_discount":"0.00","fulfillment_status":"fulfilled","tax_lines":[]}]}],"refunds":[{"id":142946243,"order_id":3797376259,"created_at":"2016-09-23T15:47:20-04:00","note":null,"restock":false,"user_id":0,"refund_line_items":[],"transactions":[{"id":4146564995,"order_id":3797376259,"amount":"100.00","kind":"refund","gateway":"","status":"success","message":"Refunded
+        100.00 from manual gateway","created_at":"2016-09-23T15:47:20-04:00","test":false,"authorization":null,"currency":"CAD","location_id":null,"user_id":null,"parent_id":4146564611,"device_id":null,"receipt":{},"error_code":null,"source_name":"1413328"}],"order_adjustments":[{"id":103566275,"order_id":3797376259,"refund_id":142946243,"amount":"-100.00","tax_amount":"0.00","kind":"refund_discrepancy","reason":"Refund
+        discrepancy"}]}],"customer":{"id":3934271555,"email":"paul.norman@example.com","accepts_marketing":false,"created_at":"2016-08-10T15:41:49-04:00","updated_at":"2016-09-23T15:47:18-04:00","first_name":"John","last_name":"Smith","orders_count":4,"state":"disabled","total_spent":"400.00","last_order_id":3797376259,"note":null,"verified_email":true,"multipass_identifier":null,"tax_exempt":false,"tags":"","last_order_name":"#1399","default_address":{"id":4150214851,"first_name":"John","last_name":"Smith","company":null,"address1":"123
         Fake Street","address2":null,"city":"Fakecity","province":"Ontario","country":"Canada","zip":"K2P
         1L4","phone":"555-555-5555","name":"John Smith","province_code":"ON","country_code":"CA","country_name":"Canada","default":true}}}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:57 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:20 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3796739523.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/orders/3797376259.json
     body:
       encoding: US-ASCII
       string: ''
@@ -461,7 +461,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:58 GMT
+      - Fri, 23 Sep 2016 19:47:21 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -477,9 +477,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -489,9 +489,9 @@ http_interactions:
       Location:
       - "/admin/orders"
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d5658139-d2c2-44cc-a1ca-1799677c3887?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b770081e-e861-47ee-ab71-9e025d70b423?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Forders&source%5Bsection%5D=admin
       X-Request-Id:
-      - d5658139-d2c2-44cc-a1ca-1799677c3887
+      - b770081e-e861-47ee-ab71-9e025d70b423
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -507,5 +507,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:58 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:21 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_already_exists_on_Shopify/does_not_create_a_new_product.yml
+++ b/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_already_exists_on_Shopify/does_not_create_a_new_product.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:04 GMT
+      - Fri, 23 Sep 2016 19:47:03 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 16/40
+      - 11/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 16/40
+      - 11/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/f9864772-4129-445c-b6a8-440a4f28521e?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/5d43ebcd-a5a1-49af-9a60-b3301cc39024?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - f9864772-4129-445c-b6a8-440a4f28521e
+      - 5d43ebcd-a5a1-49af-9a60-b3301cc39024
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,7 +64,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:04 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:03 GMT
 - request:
     method: get
     uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
@@ -88,7 +88,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:04 GMT
+      - Fri, 23 Sep 2016 19:47:03 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -104,9 +104,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 16/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 16/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -114,9 +114,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d58c1659-94c0-4b91-8913-3bc5a94a61e5?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/d4074a41-2388-43e8-a305-60edcc44c933?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - d58c1659-94c0-4b91-8913-3bc5a94a61e5
+      - d4074a41-2388-43e8-a305-60edcc44c933
       X-Dc:
       - ash
       X-Download-Options:
@@ -129,15 +129,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:04 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:03 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:04.388Z","updated_at":"2016-09-23T18:14:04.418Z","published_at":"2015-09-23T18:14:04.346Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-8","inventory_management":"shopify","updated_at":"2016-09-23T18:14:04.413Z","option1":"SKU-8"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:47:02.551Z","updated_at":"2016-09-23T19:47:02.569Z","published_at":"2015-09-23T19:47:02.509Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-15","inventory_management":"shopify","updated_at":"2016-09-23T19:47:02.564Z","option1":"SKU-15"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -157,7 +157,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:05 GMT
+      - Fri, 23 Sep 2016 19:47:04 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -171,9 +171,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 17/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 17/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -181,11 +181,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590643139
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591922883
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/12535151-a208-4b32-ac10-27c49131e2b3?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/52a6ab2f-10f5-40ac-81bd-816e703fd851?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 12535151-a208-4b32-ac10-27c49131e2b3
+      - 52a6ab2f-10f5-40ac-81bd-816e703fd851
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -199,13 +199,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590643139,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:05-04:00","published_at":"2015-09-23T14:14:04-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631113603,"product_id":8590643139,"title":"SKU-8","price":"19.99","sku":"SKU-8","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-8","option2":null,"option3":null,"created_at":"2016-09-23T14:14:05-04:00","updated_at":"2016-09-23T14:14:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314142979,"product_id":8590643139,"name":"Title","position":1,"values":["SKU-8"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922883,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:04-04:00","published_at":"2015-09-23T15:47:02-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634458051,"product_id":8591922883,"title":"SKU-15","price":"19.99","sku":"SKU-15","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-15","option2":null,"option3":null,"created_at":"2016-09-23T15:47:04-04:00","updated_at":"2016-09-23T15:47:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862531,"product_id":8591922883,"name":"Title","position":1,"values":["SKU-15"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:05 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:04 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590643139.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922883.json
     body:
       encoding: US-ASCII
       string: ''
@@ -226,7 +226,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:05 GMT
+      - Fri, 23 Sep 2016 19:47:04 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -242,9 +242,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 17/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 17/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -252,9 +252,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/315e19b6-8475-4282-a394-6d5f59485faa?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/848e5af0-c13f-4e68-8ffd-d410ca05ff31?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 315e19b6-8475-4282-a394-6d5f59485faa
+      - 848e5af0-c13f-4e68-8ffd-d410ca05ff31
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -268,17 +268,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590643139,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:05-04:00","published_at":"2015-09-23T14:14:04-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631113603,"product_id":8590643139,"title":"SKU-8","price":"19.99","sku":"SKU-8","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-8","option2":null,"option3":null,"created_at":"2016-09-23T14:14:05-04:00","updated_at":"2016-09-23T14:14:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314142979,"product_id":8590643139,"name":"Title","position":1,"values":["SKU-8"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922883,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:04-04:00","published_at":"2015-09-23T15:47:02-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634458051,"product_id":8591922883,"title":"SKU-15","price":"19.99","sku":"SKU-15","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-15","option2":null,"option3":null,"created_at":"2016-09-23T15:47:04-04:00","updated_at":"2016-09-23T15:47:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862531,"product_id":8591922883,"name":"Title","position":1,"values":["SKU-15"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:05 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:04 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590643139.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922883.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590643139,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:04.388Z","handle":"product-name","updated_at":"2016-09-23T18:14:04.418Z","published_at":"2015-09-23T18:14:04.346Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631113603,"title":"SKU-8","price":"19.99","sku":"SKU-8","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-8","option2":null,"option3":null,"created_at":"2016-09-23T14:14:05-04:00","updated_at":"2016-09-23T14:14:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314142979,"product_id":8590643139,"name":"Title","position":1,"values":["SKU-8"]}],"images":[{"variant_ids":["28631113603"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591922883,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:47:02.551Z","handle":"product-name","updated_at":"2016-09-23T19:47:02.569Z","published_at":"2015-09-23T19:47:02.509Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634458051,"title":"SKU-15","price":"19.99","sku":"SKU-15","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-15","option2":null,"option3":null,"created_at":"2016-09-23T15:47:04-04:00","updated_at":"2016-09-23T15:47:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862531,"product_id":8591922883,"name":"Title","position":1,"values":["SKU-15"]}],"images":[{"variant_ids":["28634458051"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -298,7 +298,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:05 GMT
+      - Fri, 23 Sep 2016 19:47:05 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -314,9 +314,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 13/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 13/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -324,11 +324,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590643139
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591922883
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/be55cd75-e167-467c-9d27-e069ff3673b2?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/fe9f99b9-36ce-4641-96f2-5e8678bcb290?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - be55cd75-e167-467c-9d27-e069ff3673b2
+      - fe9f99b9-36ce-4641-96f2-5e8678bcb290
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -342,10 +342,10 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590643139,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:05-04:00","published_at":"2015-09-23T14:14:04-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631113603,"product_id":8590643139,"title":"SKU-8","price":"19.99","sku":"SKU-8","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-8","option2":null,"option3":null,"created_at":"2016-09-23T14:14:05-04:00","updated_at":"2016-09-23T14:14:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314142979,"product_id":8590643139,"name":"Title","position":1,"values":["SKU-8"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922883,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:04-04:00","published_at":"2015-09-23T15:47:02-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634458051,"product_id":8591922883,"title":"SKU-15","price":"19.99","sku":"SKU-15","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-15","option2":null,"option3":null,"created_at":"2016-09-23T15:47:04-04:00","updated_at":"2016-09-23T15:47:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862531,"product_id":8591922883,"name":"Title","position":1,"values":["SKU-15"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:06 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:05 GMT
 - request:
     method: get
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
@@ -369,7 +369,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:06 GMT
+      - Fri, 23 Sep 2016 19:47:05 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -385,9 +385,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -395,9 +395,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1b7a6cb4-5a98-49cd-b02e-a03df38c15f3?source%5Baction%5D=index&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/5ec6e5be-6520-44e6-bc8a-2e12a2f83da5?source%5Baction%5D=index&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 1b7a6cb4-5a98-49cd-b02e-a03df38c15f3
+      - 5ec6e5be-6520-44e6-bc8a-2e12a2f83da5
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -3674,441 +3674,438 @@ http_interactions:
         LnNob3BpZnkuY29tXC9zXC9maWxlc1wvMVwvMDY3N1wvOTU2M1wvcHJvZHVj
         dHNcLzQ4OGQ3NGZhOWM3MDRkYzlkNDlhNWI2ZmYzZDM2OGQ1LmpwZz92PTE0
         NzQ2NDM4ODMiLCJ2YXJpYW50X2lkcyI6WzI4NjI0NTU2MjkxXX19LHsiaWQi
-        Ojg1OTAzMTM2NjcsInRpdGxlIjoiUHJvZHVjdCAjMSAtIDg3MzIiLCJib2R5
+        Ojg1OTA4Mjk2MzUsInRpdGxlIjoiUHJvZHVjdCAjMSAtIDcyODEiLCJib2R5
         X2h0bWwiOiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3Bc
         dTAwM2UiLCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlw
-        ZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjUyLTA0OjAw
-        IiwiaGFuZGxlIjoicHJvZHVjdC0xLTg3MzIiLCJ1cGRhdGVkX2F0IjoiMjAx
-        Ni0wOS0yM1QxMzo1Mzo1My0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUt
-        MDktMjNUMTM6NTM6NTEtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGws
+        ZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjI1OjM4LTA0OjAw
+        IiwiaGFuZGxlIjoicHJvZHVjdC0xLTcyODEiLCJ1cGRhdGVkX2F0IjoiMjAx
+        Ni0wOS0yM1QxNDoyNTozOS0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUt
+        MDktMjNUMTQ6MjU6MzYtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGws
         InB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50
-        cyI6W3siaWQiOjI4NjMwMzk5MTA3LCJwcm9kdWN0X2lkIjo4NTkwMzEzNjY3
+        cyI6W3siaWQiOjI4NjMxNjAzNjUxLCJwcm9kdWN0X2lkIjo4NTkwODI5NjM1
         LCJ0aXRsZSI6IlNLVS0xIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0x
         IiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5Ijoi
         ZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3Nl
         cnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3Bp
         ZnkiLCJvcHRpb24xIjoiU0tVLTEiLCJvcHRpb24yIjpudWxsLCJvcHRpb24z
-        IjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1Mzo1Mi0wNDow
-        MCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjUyLTA0OjAwIiwi
+        IjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoyNTozOC0wNDow
+        MCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjI1OjM4LTA0OjAwIiwi
         dGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGws
         ImludmVudG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91
         bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJl
-        c19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTM3MjMw
-        NzUsInByb2R1Y3RfaWQiOjg1OTAzMTM2NjcsIm5hbWUiOiJUaXRsZSIsInBv
+        c19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTQzODUw
+        OTEsInByb2R1Y3RfaWQiOjg1OTA4Mjk2MzUsIm5hbWUiOiJUaXRsZSIsInBv
         c2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTEiXX1dLCJpbWFnZXMiOltdLCJp
-        bWFnZSI6bnVsbH0seyJpZCI6ODU5MDI3OTIzNSwidGl0bGUiOiJQcm9kdWN0
-        ICMxIC0gOTI2MiIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVu
+        bWFnZSI6bnVsbH0seyJpZCI6ODU5MDMxMzY2NywidGl0bGUiOiJQcm9kdWN0
+        ICMxIC0gODczMiIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVu
         IG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVu
         ZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NTE6NTUtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTEtOTI2MiIs
-        InVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUxOjU1LTA0OjAwIiwicHVi
-        bGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxMzo1MTo1NC0wNDowMCIsInRlbXBs
+        MjNUMTM6NTM6NTItMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTEtODczMiIs
+        InVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjUzLTA0OjAwIiwicHVi
+        bGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxMzo1Mzo1MS0wNDowMCIsInRlbXBs
         YXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwi
-        dGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAzMzEyMDMsInByb2R1
-        Y3RfaWQiOjg1OTAyNzkyMzUsInRpdGxlIjoiU0tVLTE0IiwicHJpY2UiOiIx
-        OS45OSIsInNrdSI6IlNLVS0xNCIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwi
-        aW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpu
-        dWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5
-        X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0xNCIsIm9w
-        dGlvbjIiOm51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2
-        LTA5LTIzVDEzOjUxOjU1LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NTE6NTUtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpu
-        dWxsLCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3
-        ZWlnaHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlf
-        cXVhbnRpdHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlv
-        bnMiOlt7ImlkIjoxMDMxMzY3Nzc2MywicHJvZHVjdF9pZCI6ODU5MDI3OTIz
-        NSwibmFtZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1Ut
-        MTQiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDI4
-        ODgzNSwidGl0bGUiOiJQcm9kdWN0ICMxMCAtIDcwMTYiLCJib2R5X2h0bWwi
-        OiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2Ui
-        LCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIs
-        ImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUyOjI4LTA0OjAwIiwiaGFu
-        ZGxlIjoicHJvZHVjdC0xMC03MDE2IiwidXBkYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NTI6MjgtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIz
-        VDEzOjUyOjI3LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJs
-        aXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7
-        ImlkIjoyODYzMDM1MDMzOSwicHJvZHVjdF9pZCI6ODU5MDI4ODgzNSwidGl0
-        bGUiOiJTS1UtMjMiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTIzIiwi
-        cG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVu
-        eSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZp
-        Y2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnki
-        LCJvcHRpb24xIjoiU0tVLTIzIiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6
-        bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTI6MjgtMDQ6MDAi
-        LCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MjoyOC0wNDowMCIsInRh
-        eGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJp
-        bnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5p
-        dCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNf
-        c2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNjkwNDM1
-        LCJwcm9kdWN0X2lkIjo4NTkwMjg4ODM1LCJuYW1lIjoiVGl0bGUiLCJwb3Np
-        dGlvbiI6MSwidmFsdWVzIjpbIlNLVS0yMyJdfV0sImltYWdlcyI6W10sImlt
-        YWdlIjpudWxsfSx7ImlkIjo4NTkwMjQ4ODk5LCJ0aXRsZSI6IlByb2R1Y3Qg
-        IzExIC0gODA2NSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVu
-        IG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVu
-        ZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NTA6MDgtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTExLTgwNjUi
-        LCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MDowOC0wNDowMCIsInB1
-        Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTM6NTA6MDctMDQ6MDAiLCJ0ZW1w
-        bGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIs
-        InRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMwMjY3MDExLCJwcm9k
-        dWN0X2lkIjo4NTkwMjQ4ODk5LCJ0aXRsZSI6IlNLVS0yMyIsInByaWNlIjoi
-        MTkuOTkiLCJza3UiOiJTS1UtMjMiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAs
-        ImludmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6
-        bnVsbCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9y
-        eV9tYW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMjMiLCJv
-        cHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAx
-        Ni0wOS0yM1QxMzo1MDowOC0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5
-        LTIzVDEzOjUwOjA4LTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6
-        bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwi
-        d2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5
-        X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRp
-        b25zIjpbeyJpZCI6MTAzMTM2Mzg5NzksInByb2R1Y3RfaWQiOjg1OTAyNDg4
-        OTksIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tV
-        LTIzIl19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAz
-        MTQxNzksInRpdGxlIjoiUHJvZHVjdCAjMiAtIDI2NTUiLCJib2R5X2h0bWwi
-        OiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2Ui
-        LCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIs
-        ImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU0LTA0OjAwIiwiaGFu
-        ZGxlIjoicHJvZHVjdC0yLTI2NTUiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0y
-        M1QxMzo1Mzo1NS0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNU
-        MTM6NTM6NTMtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxp
-        c2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3si
-        aWQiOjI4NjMwMzk5ODc1LCJwcm9kdWN0X2lkIjo4NTkwMzE0MTc5LCJ0aXRs
-        ZSI6IlNLVS0yIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0yIiwicG9z
-        aXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIs
-        ImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2Ui
-        OiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJv
-        cHRpb24xIjoiU0tVLTIiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxs
-        LCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1Mzo1NC0wNDowMCIsInVw
-        ZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU0LTA0OjAwIiwidGF4YWJs
+        dGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAzOTkxMDcsInByb2R1
+        Y3RfaWQiOjg1OTAzMTM2NjcsInRpdGxlIjoiU0tVLTEiLCJwcmljZSI6IjE5
+        Ljk5Iiwic2t1IjoiU0tVLTEiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImlu
+        dmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVs
+        bCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9t
+        YW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMSIsIm9wdGlv
+        bjIiOm51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5
+        LTIzVDEzOjUzOjUyLTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNU
+        MTM6NTM6NTItMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxs
+        LCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWln
+        aHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVh
+        bnRpdHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMi
+        Olt7ImlkIjoxMDMxMzcyMzA3NSwicHJvZHVjdF9pZCI6ODU5MDMxMzY2Nywi
+        bmFtZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMSJd
+        fV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfSx7ImlkIjo4NTkwMjc5MjM1
+        LCJ0aXRsZSI6IlByb2R1Y3QgIzEgLSA5MjYyIiwiYm9keV9odG1sIjoiXHUw
+        MDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVu
+        ZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1NS0wNDowMCIsImhhbmRsZSI6
+        InByb2R1Y3QtMS05MjYyIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
+        NTE6NTUtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjUx
+        OjU0LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRf
+        c2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoy
+        ODYzMDMzMTIwMywicHJvZHVjdF9pZCI6ODU5MDI3OTIzNSwidGl0bGUiOiJT
+        S1UtMTQiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTE0IiwicG9zaXRp
+        b24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNv
+        bXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJt
+        YW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRp
+        b24xIjoiU0tVLTE0Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwi
+        Y3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTE6NTUtMDQ6MDAiLCJ1cGRh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1NS0wNDowMCIsInRheGFibGUi
+        OnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRv
+        cnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96
+        Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBp
+        bmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNjc3NzYzLCJwcm9k
+        dWN0X2lkIjo4NTkwMjc5MjM1LCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6
+        MSwidmFsdWVzIjpbIlNLVS0xNCJdfV0sImltYWdlcyI6W10sImltYWdlIjpu
+        dWxsfSx7ImlkIjo4NTkwMjg4ODM1LCJ0aXRsZSI6IlByb2R1Y3QgIzEwIC0g
+        NzAxNiIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRW
+        IVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwi
+        cHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
+        NTI6MjgtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTEwLTcwMTYiLCJ1cGRh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MjoyOC0wNDowMCIsInB1Ymxpc2hl
+        ZF9hdCI6IjIwMTUtMDktMjNUMTM6NTI6MjctMDQ6MDAiLCJ0ZW1wbGF0ZV9z
+        dWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3Mi
+        OiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMwMzUwMzM5LCJwcm9kdWN0X2lk
+        Ijo4NTkwMjg4ODM1LCJ0aXRsZSI6IlNLVS0yMyIsInByaWNlIjoiMTkuOTki
+        LCJza3UiOiJTS1UtMjMiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImludmVu
+        dG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVsbCwi
+        ZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9tYW5h
+        Z2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMjMiLCJvcHRpb24y
+        IjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0y
+        M1QxMzo1MjoyOC0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEz
+        OjUyOjI4LTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwi
+        aW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0
+        IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1YW50
+        aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpb
+        eyJpZCI6MTAzMTM2OTA0MzUsInByb2R1Y3RfaWQiOjg1OTAyODg4MzUsIm5h
+        bWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTIzIl19
+        XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTA4MjAyMjcs
+        InRpdGxlIjoiUHJvZHVjdCAjMTAgLSA3MjQ5IiwiYm9keV9odG1sIjoiXHUw
+        MDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVu
+        ZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoyNTowMi0wNDowMCIsImhhbmRsZSI6
+        InByb2R1Y3QtMTAtNzI0OSIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0
+        OjI1OjAzLTA0OjAwIiwicHVibGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxNDoy
+        NTowMi0wNDowMCIsInRlbXBsYXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVk
+        X3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6
+        Mjg2MzE1Nzk3NzksInByb2R1Y3RfaWQiOjg1OTA4MjAyMjcsInRpdGxlIjoi
+        U0tVLTExIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0xMSIsInBvc2l0
+        aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJj
+        b21wYXJlX2F0X3ByaWNlIjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoi
+        bWFudWFsIiwiaW52ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0
+        aW9uMSI6IlNLVS0xMSIsIm9wdGlvbjIiOm51bGwsIm9wdGlvbjMiOm51bGws
+        ImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjI1OjAyLTA0OjAwIiwidXBk
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MjU6MDItMDQ6MDAiLCJ0YXhhYmxl
+        Ijp0cnVlLCJiYXJjb2RlIjpudWxsLCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50
+        b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJv
+        eiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRpdHkiOjEsInJlcXVpcmVzX3NoaXBw
+        aW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7ImlkIjoxMDMxNDM3Mjg2NywicHJv
+        ZHVjdF9pZCI6ODU5MDgyMDIyNywibmFtZSI6IlRpdGxlIiwicG9zaXRpb24i
+        OjEsInZhbHVlcyI6WyJTS1UtMTEiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6
+        bnVsbH0seyJpZCI6ODU5MDY1MDgxOSwidGl0bGUiOiJQcm9kdWN0ICMxMSAt
+        IDIzMDQiLCJib2R5X2h0bWwiOiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBU
+        ViFcdTAwM2NcL3BcdTAwM2UiLCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIs
+        InByb2R1Y3RfdHlwZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0
+        OjE0OjI3LTA0OjAwIiwiaGFuZGxlIjoicHJvZHVjdC0xMS0yMzA0IiwidXBk
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MjctMDQ6MDAiLCJwdWJsaXNo
+        ZWRfYXQiOiIyMDE1LTA5LTIzVDE0OjE0OjI2LTA0OjAwIiwidGVtcGxhdGVf
+        c3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdz
+        IjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMTEzNDg1MSwicHJvZHVjdF9p
+        ZCI6ODU5MDY1MDgxOSwidGl0bGUiOiJTS1UtMjIiLCJwcmljZSI6IjE5Ljk5
+        Iiwic2t1IjoiU0tVLTIyIiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZl
+        bnRvcnlfcG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGws
+        ImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFu
+        YWdlbWVudCI6InNob3BpZnkiLCJvcHRpb24xIjoiU0tVLTIyIiwib3B0aW9u
+        MiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDkt
+        MjNUMTQ6MTQ6MjctMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        NDoxNDoyNy0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNvZGUiOm51bGws
+        ImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdo
+        dCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFu
+        dGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6
+        W3siaWQiOjEwMzE0MTUyNzcxLCJwcm9kdWN0X2lkIjo4NTkwNjUwODE5LCJu
+        YW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpbIlNLVS0yMiJd
+        fV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfSx7ImlkIjo4NTkwODIwNjEx
+        LCJ0aXRsZSI6IlByb2R1Y3QgIzExIC0gNjAwIiwiYm9keV9odG1sIjoiXHUw
+        MDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVu
+        ZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoyNTowNC0wNDowMCIsImhhbmRsZSI6
+        InByb2R1Y3QtMTEtNjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6
+        MjU6MDUtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDE0OjI1
+        OjAzLTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRf
+        c2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoy
+        ODYzMTU4MDE2MywicHJvZHVjdF9pZCI6ODU5MDgyMDYxMSwidGl0bGUiOiJT
+        S1UtMTIiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTEyIiwicG9zaXRp
+        b24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNv
+        bXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJt
+        YW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRp
+        b24xIjoiU0tVLTEyIiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwi
+        Y3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MjU6MDQtMDQ6MDAiLCJ1cGRh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoyNTowNC0wNDowMCIsInRheGFibGUi
+        OnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRv
+        cnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96
+        Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBp
+        bmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzE0MzczMzc5LCJwcm9k
+        dWN0X2lkIjo4NTkwODIwNjExLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6
+        MSwidmFsdWVzIjpbIlNLVS0xMiJdfV0sImltYWdlcyI6W10sImltYWdlIjpu
+        dWxsfSx7ImlkIjo4NTkwMjQ4ODk5LCJ0aXRsZSI6IlByb2R1Y3QgIzExIC0g
+        ODA2NSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRW
+        IVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwi
+        cHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
+        NTA6MDgtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTExLTgwNjUiLCJ1cGRh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MDowOC0wNDowMCIsInB1Ymxpc2hl
+        ZF9hdCI6IjIwMTUtMDktMjNUMTM6NTA6MDctMDQ6MDAiLCJ0ZW1wbGF0ZV9z
+        dWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3Mi
+        OiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMwMjY3MDExLCJwcm9kdWN0X2lk
+        Ijo4NTkwMjQ4ODk5LCJ0aXRsZSI6IlNLVS0yMyIsInByaWNlIjoiMTkuOTki
+        LCJza3UiOiJTS1UtMjMiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImludmVu
+        dG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVsbCwi
+        ZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9tYW5h
+        Z2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMjMiLCJvcHRpb24y
+        IjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0y
+        M1QxMzo1MDowOC0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEz
+        OjUwOjA4LTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwi
+        aW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0
+        IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1YW50
+        aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpb
+        eyJpZCI6MTAzMTM2Mzg5NzksInByb2R1Y3RfaWQiOjg1OTAyNDg4OTksIm5h
+        bWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTIzIl19
+        XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTA2NTE1ODcs
+        InRpdGxlIjoiUHJvZHVjdCAjMTIgLSA4NTQ5IiwiYm9keV9odG1sIjoiXHUw
+        MDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVu
+        ZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDoyOC0wNDowMCIsImhhbmRsZSI6
+        InByb2R1Y3QtMTItODU0OSIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0
+        OjE0OjI5LTA0OjAwIiwicHVibGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxNDox
+        NDoyOC0wNDowMCIsInRlbXBsYXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVk
+        X3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6
+        Mjg2MzExMzY3NzEsInByb2R1Y3RfaWQiOjg1OTA2NTE1ODcsInRpdGxlIjoi
+        U0tVLTIzIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0yMyIsInBvc2l0
+        aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJj
+        b21wYXJlX2F0X3ByaWNlIjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoi
+        bWFudWFsIiwiaW52ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0
+        aW9uMSI6IlNLVS0yMyIsIm9wdGlvbjIiOm51bGwsIm9wdGlvbjMiOm51bGws
+        ImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjI4LTA0OjAwIiwidXBk
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MjgtMDQ6MDAiLCJ0YXhhYmxl
+        Ijp0cnVlLCJiYXJjb2RlIjpudWxsLCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50
+        b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJv
+        eiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRpdHkiOjEsInJlcXVpcmVzX3NoaXBw
+        aW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7ImlkIjoxMDMxNDE1MzYwMywicHJv
+        ZHVjdF9pZCI6ODU5MDY1MTU4NywibmFtZSI6IlRpdGxlIiwicG9zaXRpb24i
+        OjEsInZhbHVlcyI6WyJTS1UtMjMiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6
+        bnVsbH0seyJpZCI6ODU5MDY1MjQxOSwidGl0bGUiOiJQcm9kdWN0ICMxNCAt
+        IDY3MjMiLCJib2R5X2h0bWwiOiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBU
+        ViFcdTAwM2NcL3BcdTAwM2UiLCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIs
+        InByb2R1Y3RfdHlwZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0
+        OjE0OjMyLTA0OjAwIiwiaGFuZGxlIjoicHJvZHVjdC0xNC02NzIzIiwidXBk
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MzMtMDQ6MDAiLCJwdWJsaXNo
+        ZWRfYXQiOiIyMDE1LTA5LTIzVDE0OjE0OjMxLTA0OjAwIiwidGVtcGxhdGVf
+        c3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdz
+        IjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMTEzODk0NywicHJvZHVjdF9p
+        ZCI6ODU5MDY1MjQxOSwidGl0bGUiOiJTS1UtMjUiLCJwcmljZSI6IjE5Ljk5
+        Iiwic2t1IjoiU0tVLTI1IiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZl
+        bnRvcnlfcG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGws
+        ImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFu
+        YWdlbWVudCI6InNob3BpZnkiLCJvcHRpb24xIjoiU0tVLTI1Iiwib3B0aW9u
+        MiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDkt
+        MjNUMTQ6MTQ6MzItMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        NDoxNDozMi0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNvZGUiOm51bGws
+        ImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdo
+        dCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFu
+        dGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6
+        W3siaWQiOjEwMzE0MTU0NjI3LCJwcm9kdWN0X2lkIjo4NTkwNjUyNDE5LCJu
+        YW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpbIlNLVS0yNSJd
+        fV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfSx7ImlkIjo4NTkwNjUyOTMx
+        LCJ0aXRsZSI6IlByb2R1Y3QgIzE1IC0gOTQ3MCIsImJvZHlfaHRtbCI6Ilx1
+        MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZl
+        bmRvciI6IkRlZmF1bHQgVmVuZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3Jl
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MzQtMDQ6MDAiLCJoYW5kbGUi
+        OiJwcm9kdWN0LTE1LTk0NzAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        NDoxNDozNS0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTQ6
+        MTQ6MzMtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hl
+        ZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQi
+        OjI4NjMxMTQwOTk1LCJwcm9kdWN0X2lkIjo4NTkwNjUyOTMxLCJ0aXRsZSI6
+        IlNLVS0yNiIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtMjYiLCJwb3Np
+        dGlvbiI6MSwiZ3JhbXMiOjAsImludmVudG9yeV9wb2xpY3kiOiJkZW55Iiwi
+        Y29tcGFyZV9hdF9wcmljZSI6bnVsbCwiZnVsZmlsbG1lbnRfc2VydmljZSI6
+        Im1hbnVhbCIsImludmVudG9yeV9tYW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9w
+        dGlvbjEiOiJTS1UtMjYiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxs
+        LCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDozNC0wNDowMCIsInVw
+        ZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjM0LTA0OjAwIiwidGF4YWJs
         ZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVu
         dG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoi
         b3oiLCJvbGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlw
-        cGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTM3MjM3MTUsInBy
-        b2R1Y3RfaWQiOjg1OTAzMTQxNzksIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9u
-        IjoxLCJ2YWx1ZXMiOlsiU0tVLTIiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6
-        bnVsbH0seyJpZCI6ODU5MDI3OTY4MywidGl0bGUiOiJQcm9kdWN0ICMyIC0g
-        ODA5NiIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRW
-        IVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwi
-        cHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NTE6NTYtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTItODA5NiIsInVwZGF0
-        ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUxOjU3LTA0OjAwIiwicHVibGlzaGVk
-        X2F0IjoiMjAxNS0wOS0yM1QxMzo1MTo1Ni0wNDowMCIsInRlbXBsYXRlX3N1
-        ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6
-        IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAzMzE3NzksInByb2R1Y3RfaWQi
-        Ojg1OTAyNzk2ODMsInRpdGxlIjoiU0tVLTE1IiwicHJpY2UiOiIxOS45OSIs
-        InNrdSI6IlNLVS0xNSIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50
-        b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJm
-        dWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFn
-        ZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0xNSIsIm9wdGlvbjIi
-        Om51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIz
-        VDEzOjUxOjU2LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NTE6NTYtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxsLCJp
-        bWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQi
-        OjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRp
-        dHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7
-        ImlkIjoxMDMxMzY3ODIxMSwicHJvZHVjdF9pZCI6ODU5MDI3OTY4MywibmFt
-        ZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMTUiXX1d
-        LCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDI4MDEzMSwi
-        dGl0bGUiOiJQcm9kdWN0ICMzIC0gMjY3IiwiYm9keV9odG1sIjoiXHUwMDNj
-        cFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9y
-        IjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVk
-        X2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1Ny0wNDowMCIsImhhbmRsZSI6InBy
-        b2R1Y3QtMy0yNjciLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1
-        OC0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTM6NTE6NTct
-        MDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29w
-        ZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMw
-        MzMzMjUxLCJwcm9kdWN0X2lkIjo4NTkwMjgwMTMxLCJ0aXRsZSI6IlNLVS0x
-        NiIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtMTYiLCJwb3NpdGlvbiI6
-        MSwiZ3JhbXMiOjAsImludmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFy
-        ZV9hdF9wcmljZSI6bnVsbCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVh
-        bCIsImludmVudG9yeV9tYW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEi
-        OiJTS1UtMTYiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVh
-        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1Ny0wNDowMCIsInVwZGF0ZWRf
-        YXQiOiIyMDE2LTA5LTIzVDEzOjUxOjU3LTA0OjAwIiwidGF4YWJsZSI6dHJ1
-        ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9x
-        dWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJv
-        bGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6
-        dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTM2Nzg3ODcsInByb2R1Y3Rf
-        aWQiOjg1OTAyODAxMzEsIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2
-        YWx1ZXMiOlsiU0tVLTE2Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9
-        LHsiaWQiOjg1OTAzMTQ0OTksInRpdGxlIjoiUHJvZHVjdCAjMyAtIDI4MDAi
-        LCJib2R5X2h0bWwiOiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAw
-        M2NcL3BcdTAwM2UiLCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1
-        Y3RfdHlwZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU1
-        LTA0OjAwIiwiaGFuZGxlIjoicHJvZHVjdC0zLTI4MDAiLCJ1cGRhdGVkX2F0
-        IjoiMjAxNi0wOS0yM1QxMzo1Mzo1Ni0wNDowMCIsInB1Ymxpc2hlZF9hdCI6
-        IjIwMTUtMDktMjNUMTM6NTM6NTUtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgi
-        Om51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2
-        YXJpYW50cyI6W3siaWQiOjI4NjMwNDAwNTc5LCJwcm9kdWN0X2lkIjo4NTkw
-        MzE0NDk5LCJ0aXRsZSI6IlNLVS0zIiwicHJpY2UiOiIxOS45OSIsInNrdSI6
-        IlNLVS0zIiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9s
-        aWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxt
-        ZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6
-        InNob3BpZnkiLCJvcHRpb24xIjoiU0tVLTMiLCJvcHRpb24yIjpudWxsLCJv
-        cHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1Mzo1
-        NS0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU1LTA0
+        cGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTQxNTUyMDMsInBy
+        b2R1Y3RfaWQiOjg1OTA2NTI5MzEsIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9u
+        IjoxLCJ2YWx1ZXMiOlsiU0tVLTI2Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2Ui
+        Om51bGx9LHsiaWQiOjg1OTA2NTM1MDcsInRpdGxlIjoiUHJvZHVjdCAjMTYg
+        LSA1Nzg1IiwiYm9keV9odG1sIjoiXHUwMDNjcFx1MDAzZUFzIHNlZW4gb24g
+        VFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9yIjoiRGVmYXVsdCBWZW5kb3Ii
+        LCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        NDoxNDozNS0wNDowMCIsImhhbmRsZSI6InByb2R1Y3QtMTYtNTc4NSIsInVw
+        ZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjM2LTA0OjAwIiwicHVibGlz
+        aGVkX2F0IjoiMjAxNS0wOS0yM1QxNDoxNDozNS0wNDowMCIsInRlbXBsYXRl
+        X3N1ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFn
+        cyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzExNDE2MzUsInByb2R1Y3Rf
+        aWQiOjg1OTA2NTM1MDcsInRpdGxlIjoiU0tVLTI3IiwicHJpY2UiOiIxOS45
+        OSIsInNrdSI6IlNLVS0yNyIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52
+        ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxs
+        LCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21h
+        bmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0yNyIsIm9wdGlv
+        bjIiOm51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5
+        LTIzVDE0OjE0OjM1LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNU
+        MTQ6MTQ6MzUtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxs
+        LCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWln
+        aHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVh
+        bnRpdHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMi
+        Olt7ImlkIjoxMDMxNDE1NTc3OSwicHJvZHVjdF9pZCI6ODU5MDY1MzUwNywi
+        bmFtZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMjci
+        XX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDY1NDQw
+        MywidGl0bGUiOiJQcm9kdWN0ICMxOCAtIDQ0ODQiLCJib2R5X2h0bWwiOiJc
+        dTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2UiLCJ2
+        ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIsImNy
+        ZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjM4LTA0OjAwIiwiaGFuZGxl
+        IjoicHJvZHVjdC0xOC00NDg0IiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNU
+        MTQ6MTQ6MzktMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDE0
+        OjE0OjM4LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNo
+        ZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7Imlk
+        IjoyODYzMTE0MzY4MywicHJvZHVjdF9pZCI6ODU5MDY1NDQwMywidGl0bGUi
+        OiJTS1UtMjkiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTI5IiwicG9z
+        aXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIs
+        ImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2Ui
+        OiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJv
+        cHRpb24xIjoiU0tVLTI5Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVs
+        bCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MzktMDQ6MDAiLCJ1
+        cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDozOS0wNDowMCIsInRheGFi
+        bGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZl
+        bnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6
+        Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hp
+        cHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzE0MTU2OTMxLCJw
+        cm9kdWN0X2lkIjo4NTkwNjU0NDAzLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlv
+        biI6MSwidmFsdWVzIjpbIlNLVS0yOSJdfV0sImltYWdlcyI6W10sImltYWdl
+        IjpudWxsfSx7ImlkIjo4NTkwNjU0Nzg3LCJ0aXRsZSI6IlByb2R1Y3QgIzE5
+        IC0gODIzNSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9u
+        IFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9y
+        IiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNU
+        MTQ6MTQ6NDAtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTE5LTgyMzUiLCJ1
+        cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDo0MS0wNDowMCIsInB1Ymxp
+        c2hlZF9hdCI6IjIwMTUtMDktMjNUMTQ6MTQ6NDAtMDQ6MDAiLCJ0ZW1wbGF0
+        ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRh
+        Z3MiOiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMxMTQ0NjQzLCJwcm9kdWN0
+        X2lkIjo4NTkwNjU0Nzg3LCJ0aXRsZSI6IlNLVS0zMCIsInByaWNlIjoiMTku
+        OTkiLCJza3UiOiJTS1UtMzAiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImlu
+        dmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVs
+        bCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9t
+        YW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMzAiLCJvcHRp
+        b24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0w
+        OS0yM1QxNDoxNDo0MC0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIz
+        VDE0OjE0OjQwLTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVs
+        bCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwid2Vp
+        Z2h0IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1
+        YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25z
+        IjpbeyJpZCI6MTAzMTQxNTc0NDMsInByb2R1Y3RfaWQiOjg1OTA2NTQ3ODcs
+        Im5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTMw
+        Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAzMTQx
+        NzksInRpdGxlIjoiUHJvZHVjdCAjMiAtIDI2NTUiLCJib2R5X2h0bWwiOiJc
+        dTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2UiLCJ2
+        ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIsImNy
+        ZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU0LTA0OjAwIiwiaGFuZGxl
+        IjoicHJvZHVjdC0yLTI2NTUiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        Mzo1Mzo1NS0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTM6
+        NTM6NTMtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hl
+        ZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQi
+        OjI4NjMwMzk5ODc1LCJwcm9kdWN0X2lkIjo4NTkwMzE0MTc5LCJ0aXRsZSI6
+        IlNLVS0yIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0yIiwicG9zaXRp
+        b24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNv
+        bXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJt
+        YW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRp
+        b24xIjoiU0tVLTIiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJj
+        cmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1Mzo1NC0wNDowMCIsInVwZGF0
+        ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU0LTA0OjAwIiwidGF4YWJsZSI6
+        dHJ1ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9y
+        eV9xdWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoib3oi
+        LCJvbGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGlu
+        ZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTM3MjM3MTUsInByb2R1
+        Y3RfaWQiOjg1OTAzMTQxNzksIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjox
+        LCJ2YWx1ZXMiOlsiU0tVLTIiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6bnVs
+        bH0seyJpZCI6ODU5MDgzMDAxOSwidGl0bGUiOiJQcm9kdWN0ICMyIC0gNjA5
+        NCIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRWIVx1
+        MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwicHJv
+        ZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MjU6
+        NDAtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTItNjA5NCIsInVwZGF0ZWRf
+        YXQiOiIyMDE2LTA5LTIzVDE0OjI1OjQxLTA0OjAwIiwicHVibGlzaGVkX2F0
+        IjoiMjAxNS0wOS0yM1QxNDoyNTo0MC0wNDowMCIsInRlbXBsYXRlX3N1ZmZp
+        eCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6IiIs
+        InZhcmlhbnRzIjpbeyJpZCI6Mjg2MzE2MDUwNTksInByb2R1Y3RfaWQiOjg1
+        OTA4MzAwMTksInRpdGxlIjoiU0tVLTIiLCJwcmljZSI6IjE5Ljk5Iiwic2t1
+        IjoiU0tVLTIiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImludmVudG9yeV9w
+        b2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVsbCwiZnVsZmls
+        bG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9tYW5hZ2VtZW50
+        Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMiIsIm9wdGlvbjIiOm51bGws
+        Im9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjI1
+        OjQwLTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MjU6NDAt
+        MDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxsLCJpbWFnZV9p
+        ZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQiOjAuMCwi
+        d2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRpdHkiOjEs
+        InJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7ImlkIjox
+        MDMxNDM4NTYwMywicHJvZHVjdF9pZCI6ODU5MDgzMDAxOSwibmFtZSI6IlRp
+        dGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMiJdfV0sImltYWdl
+        cyI6W10sImltYWdlIjpudWxsfSx7ImlkIjo4NTkwMjc5NjgzLCJ0aXRsZSI6
+        IlByb2R1Y3QgIzIgLSA4MDk2IiwiYm9keV9odG1sIjoiXHUwMDNjcFx1MDAz
+        ZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9yIjoiRGVm
+        YXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVkX2F0Ijoi
+        MjAxNi0wOS0yM1QxMzo1MTo1Ni0wNDowMCIsImhhbmRsZSI6InByb2R1Y3Qt
+        Mi04MDk2IiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTE6NTctMDQ6
+        MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjUxOjU2LTA0OjAw
+        IiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJn
+        bG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMDMzMTc3
+        OSwicHJvZHVjdF9pZCI6ODU5MDI3OTY4MywidGl0bGUiOiJTS1UtMTUiLCJw
+        cmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTE1IiwicG9zaXRpb24iOjEsImdy
+        YW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRf
+        cHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJp
+        bnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRpb24xIjoiU0tV
+        LTE1Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9h
+        dCI6IjIwMTYtMDktMjNUMTM6NTE6NTYtMDQ6MDAiLCJ1cGRhdGVkX2F0Ijoi
+        MjAxNi0wOS0yM1QxMzo1MTo1Ni0wNDowMCIsInRheGFibGUiOnRydWUsImJh
+        cmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRp
+        dHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2lu
+        dmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9
+        XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNjc4MjExLCJwcm9kdWN0X2lkIjo4
+        NTkwMjc5NjgzLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVz
+        IjpbIlNLVS0xNSJdfV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfSx7Imlk
+        Ijo4NTkwNjU1Mjk5LCJ0aXRsZSI6IlByb2R1Y3QgIzIwIC0gNzE2MiIsImJv
+        ZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRWIVx1MDAzY1wv
+        cFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwicHJvZHVjdF90
+        eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6NDItMDQ6
+        MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTIwLTcxNjIiLCJ1cGRhdGVkX2F0Ijoi
+        MjAxNi0wOS0yM1QxNDoxNDo0Mi0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIw
+        MTUtMDktMjNUMTQ6MTQ6NDEtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51
+        bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJp
+        YW50cyI6W3siaWQiOjI4NjMxMTQ1NzMxLCJwcm9kdWN0X2lkIjo4NTkwNjU1
+        Mjk5LCJ0aXRsZSI6IlNLVS0zMSIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJT
+        S1UtMzEiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImludmVudG9yeV9wb2xp
+        Y3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVsbCwiZnVsZmlsbG1l
+        bnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9tYW5hZ2VtZW50Ijoi
+        c2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMzEiLCJvcHRpb24yIjpudWxsLCJv
+        cHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDo0
+        Mi0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjQyLTA0
         OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQi
         Om51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndl
         aWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJy
         ZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAz
-        MTM3MjQxNjMsInByb2R1Y3RfaWQiOjg1OTAzMTQ0OTksIm5hbWUiOiJUaXRs
-        ZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTMiXX1dLCJpbWFnZXMi
-        OltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDI4MDgzNSwidGl0bGUiOiJQ
-        cm9kdWN0ICM0IC0gMTc5MCIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VB
+        MTQxNTgwODMsInByb2R1Y3RfaWQiOjg1OTA2NTUyOTksIm5hbWUiOiJUaXRs
+        ZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTMxIl19XSwiaW1hZ2Vz
+        IjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAyODAxMzEsInRpdGxlIjoi
+        UHJvZHVjdCAjMyAtIDI2NyIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VB
         cyBzZWVuIG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1
         bHQgVmVuZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIw
-        MTYtMDktMjNUMTM6NTE6NTktMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTQt
-        MTc5MCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUyOjAwLTA0OjAw
-        IiwicHVibGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxMzo1MTo1OS0wNDowMCIs
-        InRlbXBsYXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xv
-        YmFsIiwidGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAzMzQ5MTUs
-        InByb2R1Y3RfaWQiOjg1OTAyODA4MzUsInRpdGxlIjoiUyBcLyBTIFwvIFMi
-        LCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVUy1NXC9TS1VTLTFcL1NLVVMt
-        MlwvU0tVUy0zIiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlf
-        cG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZp
-        bGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVu
-        dCI6bnVsbCwib3B0aW9uMSI6IlMiLCJvcHRpb24yIjoiUyIsIm9wdGlvbjMi
-        OiJTIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTI6MDAtMDQ6MDAi
-        LCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MjowMC0wNDowMCIsInRh
-        eGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJp
-        bnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5p
-        dCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNf
-        c2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNjc5Njgz
-        LCJwcm9kdWN0X2lkIjo4NTkwMjgwODM1LCJuYW1lIjoiZm9vLXNpemUtOSIs
-        InBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiUyJdfSx7ImlkIjoxMDMxMzY4MDI1
-        OSwicHJvZHVjdF9pZCI6ODU5MDI4MDgzNSwibmFtZSI6ImZvby1zaXplLTEw
-        IiwicG9zaXRpb24iOjIsInZhbHVlcyI6WyJTIl19LHsiaWQiOjEwMzEzNjgw
-        MzIzLCJwcm9kdWN0X2lkIjo4NTkwMjgwODM1LCJuYW1lIjoiZm9vLXNpemUt
-        MTEiLCJwb3NpdGlvbiI6MywidmFsdWVzIjpbIlMiXX1dLCJpbWFnZXMiOltd
-        LCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDI0NzkzOSwidGl0bGUiOiJQcm9k
-        dWN0ICM2IC0gNTA3MCIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBz
-        ZWVuIG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQg
-        VmVuZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYt
-        MDktMjNUMTM6NTA6MDQtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTYtNTA3
-        MCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUwOjA1LTA0OjAwIiwi
-        cHVibGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxMzo1MDowNC0wNDowMCIsInRl
-        bXBsYXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFs
-        IiwidGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAyNjQ4OTksInBy
-        b2R1Y3RfaWQiOjg1OTAyNDc5MzksInRpdGxlIjoiU0tVLTE4IiwicHJpY2Ui
-        OiIxOS45OSIsInNrdSI6IlNLVS0xOCIsInBvc2l0aW9uIjoxLCJncmFtcyI6
-        MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNl
-        IjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50
-        b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0xOCIs
-        Im9wdGlvbjIiOm51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIy
-        MDE2LTA5LTIzVDEzOjUwOjA0LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYt
-        MDktMjNUMTM6NTA6MDQtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2Rl
-        IjpudWxsLCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5Ijox
-        LCJ3ZWlnaHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRv
-        cnlfcXVhbnRpdHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9w
-        dGlvbnMiOlt7ImlkIjoxMDMxMzYzNzc2MywicHJvZHVjdF9pZCI6ODU5MDI0
-        NzkzOSwibmFtZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJT
-        S1UtMTgiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5
-        MDE4NDY0MywidGl0bGUiOiJQcm9kdWN0IE5hbWUiLCJib2R5X2h0bWwiOiJc
-        dTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2UiLCJ2
-        ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIsImNy
-        ZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjQ2OjE2LTA0OjAwIiwiaGFuZGxl
-        IjoicHJvZHVjdC1uYW1lIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NDY6MTYtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjQ2
-        OjE1LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRf
-        c2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoy
-        ODYzMDEwOTU3MSwicHJvZHVjdF9pZCI6ODU5MDE4NDY0MywidGl0bGUiOiJT
-        S1UtMiIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtMiIsInBvc2l0aW9u
-        IjoxLCJncmFtcyI6MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21w
-        YXJlX2F0X3ByaWNlIjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFu
-        dWFsIiwiaW52ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9u
-        MSI6IlNLVS0yIiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3Jl
-        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MTYtMDQ6MDAiLCJ1cGRhdGVk
-        X2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoxNi0wNDowMCIsInRheGFibGUiOnRy
-        dWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlf
-        cXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwi
-        b2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmci
-        OnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNTUyNTc5LCJwcm9kdWN0
-        X2lkIjo4NTkwMTg0NjQzLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwi
-        dmFsdWVzIjpbIlNLVS0yIl19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9
-        LHsiaWQiOjg1OTAxODQ4MzUsInRpdGxlIjoiUHJvZHVjdCBOYW1lIiwiYm9k
-        eV9odG1sIjoiXHUwMDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9w
-        XHUwMDNlIiwidmVuZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5
-        cGUiOiIiLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoxNy0wNDow
-        MCIsImhhbmRsZSI6InByb2R1Y3QtbmFtZS0xIiwidXBkYXRlZF9hdCI6IjIw
-        MTYtMDktMjNUMTM6NDY6MTctMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1
-        LTA5LTIzVDEzOjQ2OjE3LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxs
-        LCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFu
-        dHMiOlt7ImlkIjoyODYzMDEwOTg5MSwicHJvZHVjdF9pZCI6ODU5MDE4NDgz
-        NSwidGl0bGUiOiJTS1UtNCIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJTS1Ut
-        NCIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50b3J5X3BvbGljeSI6
-        ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJmdWxmaWxsbWVudF9z
-        ZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9w
-        aWZ5Iiwib3B0aW9uMSI6IlNLVS00Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9u
-        MyI6bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MTctMDQ6
-        MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoxNy0wNDowMCIs
-        InRheGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxs
-        LCJpbnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRf
-        dW5pdCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWly
-        ZXNfc2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNTUy
-        OTYzLCJwcm9kdWN0X2lkIjo4NTkwMTg0ODM1LCJuYW1lIjoiVGl0bGUiLCJw
-        b3NpdGlvbiI6MSwidmFsdWVzIjpbIlNLVS00Il19XSwiaW1hZ2VzIjpbXSwi
-        aW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAxODUyODMsInRpdGxlIjoiUHJvZHVj
-        dCBOYW1lIiwiYm9keV9odG1sIjoiXHUwMDNjcFx1MDAzZUFzIHNlZW4gb24g
-        VFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9yIjoiRGVmYXVsdCBWZW5kb3Ii
-        LCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
-        Mzo0NjoxOC0wNDowMCIsImhhbmRsZSI6InByb2R1Y3QtbmFtZS0yIiwidXBk
-        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MTgtMDQ6MDAiLCJwdWJsaXNo
-        ZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjQ2OjE3LTA0OjAwIiwidGVtcGxhdGVf
-        c3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdz
-        IjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMDExMTA0MywicHJvZHVjdF9p
-        ZCI6ODU5MDE4NTI4MywidGl0bGUiOiJTS1UtNiIsInByaWNlIjoiMTkuOTki
-        LCJza3UiOiJTS1UtNiIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50
-        b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJm
-        dWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFn
-        ZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS02Iiwib3B0aW9uMiI6
-        bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNU
-        MTM6NDY6MTgtMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0
-        NjoxOC0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImlt
-        YWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6
-        MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0
-        eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3si
-        aWQiOjEwMzEzNTUzNTM5LCJwcm9kdWN0X2lkIjo4NTkwMTg1MjgzLCJuYW1l
-        IjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpbIlNLVS02Il19XSwi
-        aW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAxODU2NjcsInRp
-        dGxlIjoiUHJvZHVjdCBOYW1lIiwiYm9keV9odG1sIjoiXHUwMDNjcFx1MDAz
-        ZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9yIjoiRGVm
-        YXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVkX2F0Ijoi
-        MjAxNi0wOS0yM1QxMzo0NjoxOS0wNDowMCIsImhhbmRsZSI6InByb2R1Y3Qt
-        bmFtZS0zIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MTktMDQ6
-        MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjQ2OjE4LTA0OjAw
-        IiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJn
-        bG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMDExMTYx
-        OSwicHJvZHVjdF9pZCI6ODU5MDE4NTY2NywidGl0bGUiOiJTS1UtOCIsInBy
-        aWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtOCIsInBvc2l0aW9uIjoxLCJncmFt
-        cyI6MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3By
-        aWNlIjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52
-        ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS04
+        MTYtMDktMjNUMTM6NTE6NTctMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTMt
+        MjY3IiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTE6NTgtMDQ6MDAi
+        LCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjUxOjU3LTA0OjAwIiwi
+        dGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9i
+        YWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMDMzMzI1MSwi
+        cHJvZHVjdF9pZCI6ODU5MDI4MDEzMSwidGl0bGUiOiJTS1UtMTYiLCJwcmlj
+        ZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTE2IiwicG9zaXRpb24iOjEsImdyYW1z
+        IjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJp
+        Y2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZl
+        bnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRpb24xIjoiU0tVLTE2
         Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9hdCI6
-        IjIwMTYtMDktMjNUMTM6NDY6MTktMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAx
-        Ni0wOS0yM1QxMzo0NjoxOS0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNv
+        IjIwMTYtMDktMjNUMTM6NTE6NTctMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAx
+        Ni0wOS0yM1QxMzo1MTo1Ny0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNv
         ZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRpdHki
         OjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2ludmVu
         dG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9XSwi
-        b3B0aW9ucyI6W3siaWQiOjEwMzEzNTUzOTg3LCJwcm9kdWN0X2lkIjo4NTkw
-        MTg1NjY3LCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpb
-        IlNLVS04Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1
-        OTAxODU4NTksInRpdGxlIjoiUHJvZHVjdCBOYW1lIiwiYm9keV9odG1sIjoi
-        XHUwMDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwi
-        dmVuZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJj
-        cmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoyMC0wNDowMCIsImhhbmRs
-        ZSI6InByb2R1Y3QtbmFtZS00IiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNU
-        MTM6NDY6MjAtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEz
-        OjQ2OjE5LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNo
-        ZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7Imlk
-        IjoyODYzMDExMTg3NSwicHJvZHVjdF9pZCI6ODU5MDE4NTg1OSwidGl0bGUi
-        OiJTS1UtMTAiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTEwIiwicG9z
-        aXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIs
-        ImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2Ui
-        OiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJv
-        cHRpb24xIjoiU0tVLTEwIiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVs
-        bCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MjAtMDQ6MDAiLCJ1
-        cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoyMC0wNDowMCIsInRheGFi
-        bGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZl
-        bnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6
-        Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hp
-        cHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNTU0MjQzLCJw
-        cm9kdWN0X2lkIjo4NTkwMTg1ODU5LCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlv
-        biI6MSwidmFsdWVzIjpbIlNLVS0xMCJdfV0sImltYWdlcyI6W10sImltYWdl
-        IjpudWxsfSx7ImlkIjo4NTkwMTg3MDc1LCJ0aXRsZSI6IlByb2R1Y3QgTmFt
-        ZSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRWIVx1
-        MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwicHJv
-        ZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6
-        MjQtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LW5hbWUtNSIsInVwZGF0ZWRf
-        YXQiOiIyMDE2LTA5LTIzVDEzOjQ2OjI0LTA0OjAwIiwicHVibGlzaGVkX2F0
-        IjoiMjAxNS0wOS0yM1QxMzo0NjoyMy0wNDowMCIsInRlbXBsYXRlX3N1ZmZp
-        eCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6IiIs
-        InZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAxMTQzMDcsInByb2R1Y3RfaWQiOjg1
-        OTAxODcwNzUsInRpdGxlIjoiU0tVLTE3IiwicHJpY2UiOiIxOS45OSIsInNr
-        dSI6IlNLVS0xNyIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50b3J5
-        X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJmdWxm
-        aWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFnZW1l
-        bnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0xNyIsIm9wdGlvbjIiOm51
-        bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEz
-        OjQ2OjI0LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6
-        MjQtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxsLCJpbWFn
-        ZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQiOjAu
-        MCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRpdHki
-        OjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7Imlk
-        IjoxMDMxMzU1NjAzNSwicHJvZHVjdF9pZCI6ODU5MDE4NzA3NSwibmFtZSI6
-        IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMTciXX1dLCJp
-        bWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDE4NzI2NywidGl0
-        bGUiOiJQcm9kdWN0IE5hbWUiLCJib2R5X2h0bWwiOiJcdTAwM2NwXHUwMDNl
-        QXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2UiLCJ2ZW5kb3IiOiJEZWZh
-        dWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIsImNyZWF0ZWRfYXQiOiIy
-        MDE2LTA5LTIzVDEzOjQ2OjI1LTA0OjAwIiwiaGFuZGxlIjoicHJvZHVjdC1u
-        YW1lLTYiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoyNS0wNDow
-        MCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTM6NDY6MjQtMDQ6MDAi
-        LCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imds
-        b2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMwMTE0NzU1
-        LCJwcm9kdWN0X2lkIjo4NTkwMTg3MjY3LCJ0aXRsZSI6IlNLVS0xOSIsInBy
-        aWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtMTkiLCJwb3NpdGlvbiI6MSwiZ3Jh
-        bXMiOjAsImludmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9w
-        cmljZSI6bnVsbCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImlu
-        dmVudG9yeV9tYW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1Ut
-        MTkiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0
-        IjoiMjAxNi0wOS0yM1QxMzo0NjoyNS0wNDowMCIsInVwZGF0ZWRfYXQiOiIy
-        MDE2LTA5LTIzVDEzOjQ2OjI1LTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFy
-        Y29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0
-        eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52
-        ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1d
-        LCJvcHRpb25zIjpbeyJpZCI6MTAzMTM1NTYyOTEsInByb2R1Y3RfaWQiOjg1
-        OTAxODcyNjcsIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMi
-        OlsiU0tVLTE5Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQi
-        Ojg1OTAxODg2MTEsInRpdGxlIjoiUHJvZHVjdCBOYW1lIiwiYm9keV9odG1s
-        IjoiXHUwMDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNl
-        IiwidmVuZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIi
-        LCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjozMC0wNDowMCIsImhh
-        bmRsZSI6InByb2R1Y3QtbmFtZS03IiwidXBkYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NDY6MzAtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIz
-        VDEzOjQ2OjI5LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJs
-        aXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7
-        ImlkIjoyODYzMDExNjkzMSwicHJvZHVjdF9pZCI6ODU5MDE4ODYxMSwidGl0
-        bGUiOiJTS1UtMjkiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTI5Iiwi
-        cG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVu
-        eSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZp
-        Y2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnki
-        LCJvcHRpb24xIjoiU0tVLTI5Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6
-        bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MzAtMDQ6MDAi
-        LCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjozMC0wNDowMCIsInRh
-        eGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJp
-        bnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5p
-        dCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNf
-        c2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNTU4MDE5
-        LCJwcm9kdWN0X2lkIjo4NTkwMTg4NjExLCJuYW1lIjoiVGl0bGUiLCJwb3Np
-        dGlvbiI6MSwidmFsdWVzIjpbIlNLVS0yOSJdfV0sImltYWdlcyI6W10sImlt
-        YWdlIjpudWxsfSx7ImlkIjo4NTkwMTg4ODY3LCJ0aXRsZSI6IlByb2R1Y3Qg
-        TmFtZSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRW
-        IVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwi
-        cHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NDY6MzEtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LW5hbWUtOCIsInVwZGF0
-        ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjQ2OjMxLTA0OjAwIiwicHVibGlzaGVk
-        X2F0IjoiMjAxNS0wOS0yM1QxMzo0NjozMC0wNDowMCIsInRlbXBsYXRlX3N1
-        ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6
-        IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAxMTczMTUsInByb2R1Y3RfaWQi
-        Ojg1OTAxODg4NjcsInRpdGxlIjoiU0tVLTMxIiwicHJpY2UiOiIxOS45OSIs
-        InNrdSI6IlNLVS0zMSIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50
-        b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJm
-        dWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFn
-        ZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0zMSIsIm9wdGlvbjIi
-        Om51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIz
-        VDEzOjQ2OjMxLTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NDY6MzEtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxsLCJp
-        bWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQi
-        OjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRp
-        dHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7
-        ImlkIjoxMDMxMzU1ODQwMywicHJvZHVjdF9pZCI6ODU5MDE4ODg2NywibmFt
-        ZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMzEiXX1d
-        LCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH1dfQ==
+        b3B0aW9ucyI6W3siaWQiOjEwMzEzNjc4Nzg3LCJwcm9kdWN0X2lkIjo4NTkw
+        MjgwMTMxLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpb
+        IlNLVS0xNiJdfV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfV19
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:06 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:06 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590643139.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922883.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4129,7 +4126,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:06 GMT
+      - Fri, 23 Sep 2016 19:47:06 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -4145,9 +4142,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -4155,9 +4152,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/7735d460-0909-483e-ba3d-f5dc114f8872?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/11a0e0b7-0fbe-4cc5-bde6-9ed2c323abee?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 7735d460-0909-483e-ba3d-f5dc114f8872
+      - 11a0e0b7-0fbe-4cc5-bde6-9ed2c323abee
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -4171,17 +4168,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590643139,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:05-04:00","published_at":"2015-09-23T14:14:04-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631113603,"product_id":8590643139,"title":"SKU-8","price":"19.99","sku":"SKU-8","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-8","option2":null,"option3":null,"created_at":"2016-09-23T14:14:05-04:00","updated_at":"2016-09-23T14:14:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314142979,"product_id":8590643139,"name":"Title","position":1,"values":["SKU-8"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922883,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:04-04:00","published_at":"2015-09-23T15:47:02-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634458051,"product_id":8591922883,"title":"SKU-15","price":"19.99","sku":"SKU-15","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-15","option2":null,"option3":null,"created_at":"2016-09-23T15:47:04-04:00","updated_at":"2016-09-23T15:47:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862531,"product_id":8591922883,"name":"Title","position":1,"values":["SKU-15"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:06 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:06 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590643139.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922883.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590643139,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:04.388Z","handle":"product-name","updated_at":"2016-09-23T18:14:04.418Z","published_at":"2015-09-23T18:14:04.346Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631113603,"title":"SKU-8","price":"19.99","sku":"SKU-8","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-8","option2":null,"option3":null,"created_at":"2016-09-23T14:14:05-04:00","updated_at":"2016-09-23T14:14:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314142979,"product_id":8590643139,"name":"Title","position":1,"values":["SKU-8"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922883,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:47:02.551Z","handle":"product-name","updated_at":"2016-09-23T19:47:02.569Z","published_at":"2015-09-23T19:47:02.509Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634458051,"title":"SKU-15","price":"19.99","sku":"SKU-15","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-15","option2":null,"option3":null,"created_at":"2016-09-23T15:47:04-04:00","updated_at":"2016-09-23T15:47:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862531,"product_id":8591922883,"name":"Title","position":1,"values":["SKU-15"]}],"images":[],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -4201,7 +4198,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:07 GMT
+      - Fri, 23 Sep 2016 19:47:06 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -4217,9 +4214,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -4227,11 +4224,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590643139
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591922883
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/b45ecaf9-4ae1-458a-b633-d7e72900bbe1?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/4ce105b8-d874-461b-8606-46ef7e0ae0f7?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - b45ecaf9-4ae1-458a-b633-d7e72900bbe1
+      - 4ce105b8-d874-461b-8606-46ef7e0ae0f7
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -4245,10 +4242,10 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590643139,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:06-04:00","published_at":"2015-09-23T14:14:04-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631113603,"product_id":8590643139,"title":"SKU-8","price":"19.99","sku":"SKU-8","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-8","option2":null,"option3":null,"created_at":"2016-09-23T14:14:05-04:00","updated_at":"2016-09-23T14:14:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314142979,"product_id":8590643139,"name":"Title","position":1,"values":["SKU-8"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922883,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:06-04:00","published_at":"2015-09-23T15:47:02-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634458051,"product_id":8591922883,"title":"SKU-15","price":"19.99","sku":"SKU-15","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-15","option2":null,"option3":null,"created_at":"2016-09-23T15:47:04-04:00","updated_at":"2016-09-23T15:47:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862531,"product_id":8591922883,"name":"Title","position":1,"values":["SKU-15"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:07 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:06 GMT
 - request:
     method: get
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
@@ -4272,7 +4269,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:07 GMT
+      - Fri, 23 Sep 2016 19:47:07 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -4288,9 +4285,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 18/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -4298,9 +4295,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/eea6c40a-8c6a-4bf5-927b-f5638839978a?source%5Baction%5D=index&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b2e915fa-ff2f-497a-95fa-681be6c3ff48?source%5Baction%5D=index&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - eea6c40a-8c6a-4bf5-927b-f5638839978a
+      - b2e915fa-ff2f-497a-95fa-681be6c3ff48
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -7577,441 +7574,438 @@ http_interactions:
         LnNob3BpZnkuY29tXC9zXC9maWxlc1wvMVwvMDY3N1wvOTU2M1wvcHJvZHVj
         dHNcLzQ4OGQ3NGZhOWM3MDRkYzlkNDlhNWI2ZmYzZDM2OGQ1LmpwZz92PTE0
         NzQ2NDM4ODMiLCJ2YXJpYW50X2lkcyI6WzI4NjI0NTU2MjkxXX19LHsiaWQi
-        Ojg1OTAzMTM2NjcsInRpdGxlIjoiUHJvZHVjdCAjMSAtIDg3MzIiLCJib2R5
+        Ojg1OTA4Mjk2MzUsInRpdGxlIjoiUHJvZHVjdCAjMSAtIDcyODEiLCJib2R5
         X2h0bWwiOiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3Bc
         dTAwM2UiLCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlw
-        ZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjUyLTA0OjAw
-        IiwiaGFuZGxlIjoicHJvZHVjdC0xLTg3MzIiLCJ1cGRhdGVkX2F0IjoiMjAx
-        Ni0wOS0yM1QxMzo1Mzo1My0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUt
-        MDktMjNUMTM6NTM6NTEtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGws
+        ZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjI1OjM4LTA0OjAw
+        IiwiaGFuZGxlIjoicHJvZHVjdC0xLTcyODEiLCJ1cGRhdGVkX2F0IjoiMjAx
+        Ni0wOS0yM1QxNDoyNTozOS0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUt
+        MDktMjNUMTQ6MjU6MzYtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGws
         InB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50
-        cyI6W3siaWQiOjI4NjMwMzk5MTA3LCJwcm9kdWN0X2lkIjo4NTkwMzEzNjY3
+        cyI6W3siaWQiOjI4NjMxNjAzNjUxLCJwcm9kdWN0X2lkIjo4NTkwODI5NjM1
         LCJ0aXRsZSI6IlNLVS0xIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0x
         IiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5Ijoi
         ZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3Nl
         cnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3Bp
         ZnkiLCJvcHRpb24xIjoiU0tVLTEiLCJvcHRpb24yIjpudWxsLCJvcHRpb24z
-        IjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1Mzo1Mi0wNDow
-        MCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjUyLTA0OjAwIiwi
+        IjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoyNTozOC0wNDow
+        MCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjI1OjM4LTA0OjAwIiwi
         dGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGws
         ImludmVudG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91
         bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJl
-        c19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTM3MjMw
-        NzUsInByb2R1Y3RfaWQiOjg1OTAzMTM2NjcsIm5hbWUiOiJUaXRsZSIsInBv
+        c19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTQzODUw
+        OTEsInByb2R1Y3RfaWQiOjg1OTA4Mjk2MzUsIm5hbWUiOiJUaXRsZSIsInBv
         c2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTEiXX1dLCJpbWFnZXMiOltdLCJp
-        bWFnZSI6bnVsbH0seyJpZCI6ODU5MDI3OTIzNSwidGl0bGUiOiJQcm9kdWN0
-        ICMxIC0gOTI2MiIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVu
+        bWFnZSI6bnVsbH0seyJpZCI6ODU5MDMxMzY2NywidGl0bGUiOiJQcm9kdWN0
+        ICMxIC0gODczMiIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVu
         IG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVu
         ZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NTE6NTUtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTEtOTI2MiIs
-        InVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUxOjU1LTA0OjAwIiwicHVi
-        bGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxMzo1MTo1NC0wNDowMCIsInRlbXBs
+        MjNUMTM6NTM6NTItMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTEtODczMiIs
+        InVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjUzLTA0OjAwIiwicHVi
+        bGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxMzo1Mzo1MS0wNDowMCIsInRlbXBs
         YXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwi
-        dGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAzMzEyMDMsInByb2R1
-        Y3RfaWQiOjg1OTAyNzkyMzUsInRpdGxlIjoiU0tVLTE0IiwicHJpY2UiOiIx
-        OS45OSIsInNrdSI6IlNLVS0xNCIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwi
-        aW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpu
-        dWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5
-        X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0xNCIsIm9w
-        dGlvbjIiOm51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2
-        LTA5LTIzVDEzOjUxOjU1LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NTE6NTUtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpu
-        dWxsLCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3
-        ZWlnaHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlf
-        cXVhbnRpdHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlv
-        bnMiOlt7ImlkIjoxMDMxMzY3Nzc2MywicHJvZHVjdF9pZCI6ODU5MDI3OTIz
-        NSwibmFtZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1Ut
-        MTQiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDI4
-        ODgzNSwidGl0bGUiOiJQcm9kdWN0ICMxMCAtIDcwMTYiLCJib2R5X2h0bWwi
-        OiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2Ui
-        LCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIs
-        ImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUyOjI4LTA0OjAwIiwiaGFu
-        ZGxlIjoicHJvZHVjdC0xMC03MDE2IiwidXBkYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NTI6MjgtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIz
-        VDEzOjUyOjI3LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJs
-        aXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7
-        ImlkIjoyODYzMDM1MDMzOSwicHJvZHVjdF9pZCI6ODU5MDI4ODgzNSwidGl0
-        bGUiOiJTS1UtMjMiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTIzIiwi
-        cG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVu
-        eSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZp
-        Y2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnki
-        LCJvcHRpb24xIjoiU0tVLTIzIiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6
-        bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTI6MjgtMDQ6MDAi
-        LCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MjoyOC0wNDowMCIsInRh
-        eGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJp
-        bnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5p
-        dCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNf
-        c2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNjkwNDM1
-        LCJwcm9kdWN0X2lkIjo4NTkwMjg4ODM1LCJuYW1lIjoiVGl0bGUiLCJwb3Np
-        dGlvbiI6MSwidmFsdWVzIjpbIlNLVS0yMyJdfV0sImltYWdlcyI6W10sImlt
-        YWdlIjpudWxsfSx7ImlkIjo4NTkwMjQ4ODk5LCJ0aXRsZSI6IlByb2R1Y3Qg
-        IzExIC0gODA2NSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVu
-        IG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVu
-        ZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NTA6MDgtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTExLTgwNjUi
-        LCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MDowOC0wNDowMCIsInB1
-        Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTM6NTA6MDctMDQ6MDAiLCJ0ZW1w
-        bGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIs
-        InRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMwMjY3MDExLCJwcm9k
-        dWN0X2lkIjo4NTkwMjQ4ODk5LCJ0aXRsZSI6IlNLVS0yMyIsInByaWNlIjoi
-        MTkuOTkiLCJza3UiOiJTS1UtMjMiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAs
-        ImludmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6
-        bnVsbCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9y
-        eV9tYW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMjMiLCJv
-        cHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAx
-        Ni0wOS0yM1QxMzo1MDowOC0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5
-        LTIzVDEzOjUwOjA4LTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6
-        bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwi
-        d2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5
-        X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRp
-        b25zIjpbeyJpZCI6MTAzMTM2Mzg5NzksInByb2R1Y3RfaWQiOjg1OTAyNDg4
-        OTksIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tV
-        LTIzIl19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAz
-        MTQxNzksInRpdGxlIjoiUHJvZHVjdCAjMiAtIDI2NTUiLCJib2R5X2h0bWwi
-        OiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2Ui
-        LCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIs
-        ImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU0LTA0OjAwIiwiaGFu
-        ZGxlIjoicHJvZHVjdC0yLTI2NTUiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0y
-        M1QxMzo1Mzo1NS0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNU
-        MTM6NTM6NTMtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxp
-        c2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3si
-        aWQiOjI4NjMwMzk5ODc1LCJwcm9kdWN0X2lkIjo4NTkwMzE0MTc5LCJ0aXRs
-        ZSI6IlNLVS0yIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0yIiwicG9z
-        aXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIs
-        ImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2Ui
-        OiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJv
-        cHRpb24xIjoiU0tVLTIiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxs
-        LCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1Mzo1NC0wNDowMCIsInVw
-        ZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU0LTA0OjAwIiwidGF4YWJs
+        dGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAzOTkxMDcsInByb2R1
+        Y3RfaWQiOjg1OTAzMTM2NjcsInRpdGxlIjoiU0tVLTEiLCJwcmljZSI6IjE5
+        Ljk5Iiwic2t1IjoiU0tVLTEiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImlu
+        dmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVs
+        bCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9t
+        YW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMSIsIm9wdGlv
+        bjIiOm51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5
+        LTIzVDEzOjUzOjUyLTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNU
+        MTM6NTM6NTItMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxs
+        LCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWln
+        aHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVh
+        bnRpdHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMi
+        Olt7ImlkIjoxMDMxMzcyMzA3NSwicHJvZHVjdF9pZCI6ODU5MDMxMzY2Nywi
+        bmFtZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMSJd
+        fV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfSx7ImlkIjo4NTkwMjc5MjM1
+        LCJ0aXRsZSI6IlByb2R1Y3QgIzEgLSA5MjYyIiwiYm9keV9odG1sIjoiXHUw
+        MDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVu
+        ZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1NS0wNDowMCIsImhhbmRsZSI6
+        InByb2R1Y3QtMS05MjYyIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
+        NTE6NTUtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjUx
+        OjU0LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRf
+        c2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoy
+        ODYzMDMzMTIwMywicHJvZHVjdF9pZCI6ODU5MDI3OTIzNSwidGl0bGUiOiJT
+        S1UtMTQiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTE0IiwicG9zaXRp
+        b24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNv
+        bXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJt
+        YW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRp
+        b24xIjoiU0tVLTE0Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwi
+        Y3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTE6NTUtMDQ6MDAiLCJ1cGRh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1NS0wNDowMCIsInRheGFibGUi
+        OnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRv
+        cnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96
+        Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBp
+        bmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNjc3NzYzLCJwcm9k
+        dWN0X2lkIjo4NTkwMjc5MjM1LCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6
+        MSwidmFsdWVzIjpbIlNLVS0xNCJdfV0sImltYWdlcyI6W10sImltYWdlIjpu
+        dWxsfSx7ImlkIjo4NTkwMjg4ODM1LCJ0aXRsZSI6IlByb2R1Y3QgIzEwIC0g
+        NzAxNiIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRW
+        IVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwi
+        cHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
+        NTI6MjgtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTEwLTcwMTYiLCJ1cGRh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MjoyOC0wNDowMCIsInB1Ymxpc2hl
+        ZF9hdCI6IjIwMTUtMDktMjNUMTM6NTI6MjctMDQ6MDAiLCJ0ZW1wbGF0ZV9z
+        dWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3Mi
+        OiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMwMzUwMzM5LCJwcm9kdWN0X2lk
+        Ijo4NTkwMjg4ODM1LCJ0aXRsZSI6IlNLVS0yMyIsInByaWNlIjoiMTkuOTki
+        LCJza3UiOiJTS1UtMjMiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImludmVu
+        dG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVsbCwi
+        ZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9tYW5h
+        Z2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMjMiLCJvcHRpb24y
+        IjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0y
+        M1QxMzo1MjoyOC0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEz
+        OjUyOjI4LTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwi
+        aW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0
+        IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1YW50
+        aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpb
+        eyJpZCI6MTAzMTM2OTA0MzUsInByb2R1Y3RfaWQiOjg1OTAyODg4MzUsIm5h
+        bWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTIzIl19
+        XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTA4MjAyMjcs
+        InRpdGxlIjoiUHJvZHVjdCAjMTAgLSA3MjQ5IiwiYm9keV9odG1sIjoiXHUw
+        MDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVu
+        ZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoyNTowMi0wNDowMCIsImhhbmRsZSI6
+        InByb2R1Y3QtMTAtNzI0OSIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0
+        OjI1OjAzLTA0OjAwIiwicHVibGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxNDoy
+        NTowMi0wNDowMCIsInRlbXBsYXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVk
+        X3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6
+        Mjg2MzE1Nzk3NzksInByb2R1Y3RfaWQiOjg1OTA4MjAyMjcsInRpdGxlIjoi
+        U0tVLTExIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0xMSIsInBvc2l0
+        aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJj
+        b21wYXJlX2F0X3ByaWNlIjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoi
+        bWFudWFsIiwiaW52ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0
+        aW9uMSI6IlNLVS0xMSIsIm9wdGlvbjIiOm51bGwsIm9wdGlvbjMiOm51bGws
+        ImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjI1OjAyLTA0OjAwIiwidXBk
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MjU6MDItMDQ6MDAiLCJ0YXhhYmxl
+        Ijp0cnVlLCJiYXJjb2RlIjpudWxsLCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50
+        b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJv
+        eiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRpdHkiOjEsInJlcXVpcmVzX3NoaXBw
+        aW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7ImlkIjoxMDMxNDM3Mjg2NywicHJv
+        ZHVjdF9pZCI6ODU5MDgyMDIyNywibmFtZSI6IlRpdGxlIiwicG9zaXRpb24i
+        OjEsInZhbHVlcyI6WyJTS1UtMTEiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6
+        bnVsbH0seyJpZCI6ODU5MDY1MDgxOSwidGl0bGUiOiJQcm9kdWN0ICMxMSAt
+        IDIzMDQiLCJib2R5X2h0bWwiOiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBU
+        ViFcdTAwM2NcL3BcdTAwM2UiLCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIs
+        InByb2R1Y3RfdHlwZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0
+        OjE0OjI3LTA0OjAwIiwiaGFuZGxlIjoicHJvZHVjdC0xMS0yMzA0IiwidXBk
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MjctMDQ6MDAiLCJwdWJsaXNo
+        ZWRfYXQiOiIyMDE1LTA5LTIzVDE0OjE0OjI2LTA0OjAwIiwidGVtcGxhdGVf
+        c3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdz
+        IjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMTEzNDg1MSwicHJvZHVjdF9p
+        ZCI6ODU5MDY1MDgxOSwidGl0bGUiOiJTS1UtMjIiLCJwcmljZSI6IjE5Ljk5
+        Iiwic2t1IjoiU0tVLTIyIiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZl
+        bnRvcnlfcG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGws
+        ImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFu
+        YWdlbWVudCI6InNob3BpZnkiLCJvcHRpb24xIjoiU0tVLTIyIiwib3B0aW9u
+        MiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDkt
+        MjNUMTQ6MTQ6MjctMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        NDoxNDoyNy0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNvZGUiOm51bGws
+        ImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdo
+        dCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFu
+        dGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6
+        W3siaWQiOjEwMzE0MTUyNzcxLCJwcm9kdWN0X2lkIjo4NTkwNjUwODE5LCJu
+        YW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpbIlNLVS0yMiJd
+        fV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfSx7ImlkIjo4NTkwODIwNjEx
+        LCJ0aXRsZSI6IlByb2R1Y3QgIzExIC0gNjAwIiwiYm9keV9odG1sIjoiXHUw
+        MDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVu
+        ZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoyNTowNC0wNDowMCIsImhhbmRsZSI6
+        InByb2R1Y3QtMTEtNjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6
+        MjU6MDUtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDE0OjI1
+        OjAzLTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRf
+        c2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoy
+        ODYzMTU4MDE2MywicHJvZHVjdF9pZCI6ODU5MDgyMDYxMSwidGl0bGUiOiJT
+        S1UtMTIiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTEyIiwicG9zaXRp
+        b24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNv
+        bXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJt
+        YW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRp
+        b24xIjoiU0tVLTEyIiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwi
+        Y3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MjU6MDQtMDQ6MDAiLCJ1cGRh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoyNTowNC0wNDowMCIsInRheGFibGUi
+        OnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRv
+        cnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96
+        Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBp
+        bmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzE0MzczMzc5LCJwcm9k
+        dWN0X2lkIjo4NTkwODIwNjExLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6
+        MSwidmFsdWVzIjpbIlNLVS0xMiJdfV0sImltYWdlcyI6W10sImltYWdlIjpu
+        dWxsfSx7ImlkIjo4NTkwMjQ4ODk5LCJ0aXRsZSI6IlByb2R1Y3QgIzExIC0g
+        ODA2NSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRW
+        IVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwi
+        cHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
+        NTA6MDgtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTExLTgwNjUiLCJ1cGRh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MDowOC0wNDowMCIsInB1Ymxpc2hl
+        ZF9hdCI6IjIwMTUtMDktMjNUMTM6NTA6MDctMDQ6MDAiLCJ0ZW1wbGF0ZV9z
+        dWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3Mi
+        OiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMwMjY3MDExLCJwcm9kdWN0X2lk
+        Ijo4NTkwMjQ4ODk5LCJ0aXRsZSI6IlNLVS0yMyIsInByaWNlIjoiMTkuOTki
+        LCJza3UiOiJTS1UtMjMiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImludmVu
+        dG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVsbCwi
+        ZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9tYW5h
+        Z2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMjMiLCJvcHRpb24y
+        IjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0y
+        M1QxMzo1MDowOC0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEz
+        OjUwOjA4LTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwi
+        aW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0
+        IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1YW50
+        aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpb
+        eyJpZCI6MTAzMTM2Mzg5NzksInByb2R1Y3RfaWQiOjg1OTAyNDg4OTksIm5h
+        bWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTIzIl19
+        XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTA2NTE1ODcs
+        InRpdGxlIjoiUHJvZHVjdCAjMTIgLSA4NTQ5IiwiYm9keV9odG1sIjoiXHUw
+        MDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVu
+        ZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVh
+        dGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDoyOC0wNDowMCIsImhhbmRsZSI6
+        InByb2R1Y3QtMTItODU0OSIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0
+        OjE0OjI5LTA0OjAwIiwicHVibGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxNDox
+        NDoyOC0wNDowMCIsInRlbXBsYXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVk
+        X3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6
+        Mjg2MzExMzY3NzEsInByb2R1Y3RfaWQiOjg1OTA2NTE1ODcsInRpdGxlIjoi
+        U0tVLTIzIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0yMyIsInBvc2l0
+        aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJj
+        b21wYXJlX2F0X3ByaWNlIjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoi
+        bWFudWFsIiwiaW52ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0
+        aW9uMSI6IlNLVS0yMyIsIm9wdGlvbjIiOm51bGwsIm9wdGlvbjMiOm51bGws
+        ImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjI4LTA0OjAwIiwidXBk
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MjgtMDQ6MDAiLCJ0YXhhYmxl
+        Ijp0cnVlLCJiYXJjb2RlIjpudWxsLCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50
+        b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJv
+        eiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRpdHkiOjEsInJlcXVpcmVzX3NoaXBw
+        aW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7ImlkIjoxMDMxNDE1MzYwMywicHJv
+        ZHVjdF9pZCI6ODU5MDY1MTU4NywibmFtZSI6IlRpdGxlIiwicG9zaXRpb24i
+        OjEsInZhbHVlcyI6WyJTS1UtMjMiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6
+        bnVsbH0seyJpZCI6ODU5MDY1MjQxOSwidGl0bGUiOiJQcm9kdWN0ICMxNCAt
+        IDY3MjMiLCJib2R5X2h0bWwiOiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBU
+        ViFcdTAwM2NcL3BcdTAwM2UiLCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIs
+        InByb2R1Y3RfdHlwZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0
+        OjE0OjMyLTA0OjAwIiwiaGFuZGxlIjoicHJvZHVjdC0xNC02NzIzIiwidXBk
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MzMtMDQ6MDAiLCJwdWJsaXNo
+        ZWRfYXQiOiIyMDE1LTA5LTIzVDE0OjE0OjMxLTA0OjAwIiwidGVtcGxhdGVf
+        c3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdz
+        IjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMTEzODk0NywicHJvZHVjdF9p
+        ZCI6ODU5MDY1MjQxOSwidGl0bGUiOiJTS1UtMjUiLCJwcmljZSI6IjE5Ljk5
+        Iiwic2t1IjoiU0tVLTI1IiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZl
+        bnRvcnlfcG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGws
+        ImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFu
+        YWdlbWVudCI6InNob3BpZnkiLCJvcHRpb24xIjoiU0tVLTI1Iiwib3B0aW9u
+        MiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDkt
+        MjNUMTQ6MTQ6MzItMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        NDoxNDozMi0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNvZGUiOm51bGws
+        ImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdo
+        dCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFu
+        dGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6
+        W3siaWQiOjEwMzE0MTU0NjI3LCJwcm9kdWN0X2lkIjo4NTkwNjUyNDE5LCJu
+        YW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpbIlNLVS0yNSJd
+        fV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfSx7ImlkIjo4NTkwNjUyOTMx
+        LCJ0aXRsZSI6IlByb2R1Y3QgIzE1IC0gOTQ3MCIsImJvZHlfaHRtbCI6Ilx1
+        MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZl
+        bmRvciI6IkRlZmF1bHQgVmVuZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3Jl
+        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MzQtMDQ6MDAiLCJoYW5kbGUi
+        OiJwcm9kdWN0LTE1LTk0NzAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        NDoxNDozNS0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTQ6
+        MTQ6MzMtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hl
+        ZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQi
+        OjI4NjMxMTQwOTk1LCJwcm9kdWN0X2lkIjo4NTkwNjUyOTMxLCJ0aXRsZSI6
+        IlNLVS0yNiIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtMjYiLCJwb3Np
+        dGlvbiI6MSwiZ3JhbXMiOjAsImludmVudG9yeV9wb2xpY3kiOiJkZW55Iiwi
+        Y29tcGFyZV9hdF9wcmljZSI6bnVsbCwiZnVsZmlsbG1lbnRfc2VydmljZSI6
+        Im1hbnVhbCIsImludmVudG9yeV9tYW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9w
+        dGlvbjEiOiJTS1UtMjYiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxs
+        LCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDozNC0wNDowMCIsInVw
+        ZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjM0LTA0OjAwIiwidGF4YWJs
         ZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVu
         dG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoi
         b3oiLCJvbGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlw
-        cGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTM3MjM3MTUsInBy
-        b2R1Y3RfaWQiOjg1OTAzMTQxNzksIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9u
-        IjoxLCJ2YWx1ZXMiOlsiU0tVLTIiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6
-        bnVsbH0seyJpZCI6ODU5MDI3OTY4MywidGl0bGUiOiJQcm9kdWN0ICMyIC0g
-        ODA5NiIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRW
-        IVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwi
-        cHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NTE6NTYtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTItODA5NiIsInVwZGF0
-        ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUxOjU3LTA0OjAwIiwicHVibGlzaGVk
-        X2F0IjoiMjAxNS0wOS0yM1QxMzo1MTo1Ni0wNDowMCIsInRlbXBsYXRlX3N1
-        ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6
-        IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAzMzE3NzksInByb2R1Y3RfaWQi
-        Ojg1OTAyNzk2ODMsInRpdGxlIjoiU0tVLTE1IiwicHJpY2UiOiIxOS45OSIs
-        InNrdSI6IlNLVS0xNSIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50
-        b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJm
-        dWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFn
-        ZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0xNSIsIm9wdGlvbjIi
-        Om51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIz
-        VDEzOjUxOjU2LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NTE6NTYtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxsLCJp
-        bWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQi
-        OjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRp
-        dHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7
-        ImlkIjoxMDMxMzY3ODIxMSwicHJvZHVjdF9pZCI6ODU5MDI3OTY4MywibmFt
-        ZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMTUiXX1d
-        LCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDI4MDEzMSwi
-        dGl0bGUiOiJQcm9kdWN0ICMzIC0gMjY3IiwiYm9keV9odG1sIjoiXHUwMDNj
-        cFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9y
-        IjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVk
-        X2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1Ny0wNDowMCIsImhhbmRsZSI6InBy
-        b2R1Y3QtMy0yNjciLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1
-        OC0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTM6NTE6NTct
-        MDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29w
-        ZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMw
-        MzMzMjUxLCJwcm9kdWN0X2lkIjo4NTkwMjgwMTMxLCJ0aXRsZSI6IlNLVS0x
-        NiIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtMTYiLCJwb3NpdGlvbiI6
-        MSwiZ3JhbXMiOjAsImludmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFy
-        ZV9hdF9wcmljZSI6bnVsbCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVh
-        bCIsImludmVudG9yeV9tYW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEi
-        OiJTS1UtMTYiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVh
-        dGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MTo1Ny0wNDowMCIsInVwZGF0ZWRf
-        YXQiOiIyMDE2LTA5LTIzVDEzOjUxOjU3LTA0OjAwIiwidGF4YWJsZSI6dHJ1
-        ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9x
-        dWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJv
-        bGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6
-        dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTM2Nzg3ODcsInByb2R1Y3Rf
-        aWQiOjg1OTAyODAxMzEsIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2
-        YWx1ZXMiOlsiU0tVLTE2Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9
-        LHsiaWQiOjg1OTAzMTQ0OTksInRpdGxlIjoiUHJvZHVjdCAjMyAtIDI4MDAi
-        LCJib2R5X2h0bWwiOiJcdTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAw
-        M2NcL3BcdTAwM2UiLCJ2ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1
-        Y3RfdHlwZSI6IiIsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU1
-        LTA0OjAwIiwiaGFuZGxlIjoicHJvZHVjdC0zLTI4MDAiLCJ1cGRhdGVkX2F0
-        IjoiMjAxNi0wOS0yM1QxMzo1Mzo1Ni0wNDowMCIsInB1Ymxpc2hlZF9hdCI6
-        IjIwMTUtMDktMjNUMTM6NTM6NTUtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgi
-        Om51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2
-        YXJpYW50cyI6W3siaWQiOjI4NjMwNDAwNTc5LCJwcm9kdWN0X2lkIjo4NTkw
-        MzE0NDk5LCJ0aXRsZSI6IlNLVS0zIiwicHJpY2UiOiIxOS45OSIsInNrdSI6
-        IlNLVS0zIiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9s
-        aWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxt
-        ZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6
-        InNob3BpZnkiLCJvcHRpb24xIjoiU0tVLTMiLCJvcHRpb24yIjpudWxsLCJv
-        cHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1Mzo1
-        NS0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU1LTA0
+        cGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTQxNTUyMDMsInBy
+        b2R1Y3RfaWQiOjg1OTA2NTI5MzEsIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9u
+        IjoxLCJ2YWx1ZXMiOlsiU0tVLTI2Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2Ui
+        Om51bGx9LHsiaWQiOjg1OTA2NTM1MDcsInRpdGxlIjoiUHJvZHVjdCAjMTYg
+        LSA1Nzg1IiwiYm9keV9odG1sIjoiXHUwMDNjcFx1MDAzZUFzIHNlZW4gb24g
+        VFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9yIjoiRGVmYXVsdCBWZW5kb3Ii
+        LCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        NDoxNDozNS0wNDowMCIsImhhbmRsZSI6InByb2R1Y3QtMTYtNTc4NSIsInVw
+        ZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjM2LTA0OjAwIiwicHVibGlz
+        aGVkX2F0IjoiMjAxNS0wOS0yM1QxNDoxNDozNS0wNDowMCIsInRlbXBsYXRl
+        X3N1ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFn
+        cyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzExNDE2MzUsInByb2R1Y3Rf
+        aWQiOjg1OTA2NTM1MDcsInRpdGxlIjoiU0tVLTI3IiwicHJpY2UiOiIxOS45
+        OSIsInNrdSI6IlNLVS0yNyIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52
+        ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxs
+        LCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21h
+        bmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0yNyIsIm9wdGlv
+        bjIiOm51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5
+        LTIzVDE0OjE0OjM1LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNU
+        MTQ6MTQ6MzUtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxs
+        LCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWln
+        aHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVh
+        bnRpdHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMi
+        Olt7ImlkIjoxMDMxNDE1NTc3OSwicHJvZHVjdF9pZCI6ODU5MDY1MzUwNywi
+        bmFtZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMjci
+        XX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDY1NDQw
+        MywidGl0bGUiOiJQcm9kdWN0ICMxOCAtIDQ0ODQiLCJib2R5X2h0bWwiOiJc
+        dTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2UiLCJ2
+        ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIsImNy
+        ZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjM4LTA0OjAwIiwiaGFuZGxl
+        IjoicHJvZHVjdC0xOC00NDg0IiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNU
+        MTQ6MTQ6MzktMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDE0
+        OjE0OjM4LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNo
+        ZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7Imlk
+        IjoyODYzMTE0MzY4MywicHJvZHVjdF9pZCI6ODU5MDY1NDQwMywidGl0bGUi
+        OiJTS1UtMjkiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTI5IiwicG9z
+        aXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIs
+        ImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2Ui
+        OiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJv
+        cHRpb24xIjoiU0tVLTI5Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVs
+        bCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6MzktMDQ6MDAiLCJ1
+        cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDozOS0wNDowMCIsInRheGFi
+        bGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZl
+        bnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6
+        Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hp
+        cHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzE0MTU2OTMxLCJw
+        cm9kdWN0X2lkIjo4NTkwNjU0NDAzLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlv
+        biI6MSwidmFsdWVzIjpbIlNLVS0yOSJdfV0sImltYWdlcyI6W10sImltYWdl
+        IjpudWxsfSx7ImlkIjo4NTkwNjU0Nzg3LCJ0aXRsZSI6IlByb2R1Y3QgIzE5
+        IC0gODIzNSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9u
+        IFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9y
+        IiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNU
+        MTQ6MTQ6NDAtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTE5LTgyMzUiLCJ1
+        cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDo0MS0wNDowMCIsInB1Ymxp
+        c2hlZF9hdCI6IjIwMTUtMDktMjNUMTQ6MTQ6NDAtMDQ6MDAiLCJ0ZW1wbGF0
+        ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRh
+        Z3MiOiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMxMTQ0NjQzLCJwcm9kdWN0
+        X2lkIjo4NTkwNjU0Nzg3LCJ0aXRsZSI6IlNLVS0zMCIsInByaWNlIjoiMTku
+        OTkiLCJza3UiOiJTS1UtMzAiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImlu
+        dmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVs
+        bCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9t
+        YW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMzAiLCJvcHRp
+        b24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0w
+        OS0yM1QxNDoxNDo0MC0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIz
+        VDE0OjE0OjQwLTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVs
+        bCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwid2Vp
+        Z2h0IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1
+        YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25z
+        IjpbeyJpZCI6MTAzMTQxNTc0NDMsInByb2R1Y3RfaWQiOjg1OTA2NTQ3ODcs
+        Im5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTMw
+        Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAzMTQx
+        NzksInRpdGxlIjoiUHJvZHVjdCAjMiAtIDI2NTUiLCJib2R5X2h0bWwiOiJc
+        dTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2UiLCJ2
+        ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIsImNy
+        ZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU0LTA0OjAwIiwiaGFuZGxl
+        IjoicHJvZHVjdC0yLTI2NTUiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
+        Mzo1Mzo1NS0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTM6
+        NTM6NTMtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hl
+        ZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQi
+        OjI4NjMwMzk5ODc1LCJwcm9kdWN0X2lkIjo4NTkwMzE0MTc5LCJ0aXRsZSI6
+        IlNLVS0yIiwicHJpY2UiOiIxOS45OSIsInNrdSI6IlNLVS0yIiwicG9zaXRp
+        b24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNv
+        bXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJt
+        YW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRp
+        b24xIjoiU0tVLTIiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJj
+        cmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1Mzo1NC0wNDowMCIsInVwZGF0
+        ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUzOjU0LTA0OjAwIiwidGF4YWJsZSI6
+        dHJ1ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9y
+        eV9xdWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoib3oi
+        LCJvbGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGlu
+        ZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAzMTM3MjM3MTUsInByb2R1
+        Y3RfaWQiOjg1OTAzMTQxNzksIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjox
+        LCJ2YWx1ZXMiOlsiU0tVLTIiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6bnVs
+        bH0seyJpZCI6ODU5MDgzMDAxOSwidGl0bGUiOiJQcm9kdWN0ICMyIC0gNjA5
+        NCIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRWIVx1
+        MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwicHJv
+        ZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MjU6
+        NDAtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTItNjA5NCIsInVwZGF0ZWRf
+        YXQiOiIyMDE2LTA5LTIzVDE0OjI1OjQxLTA0OjAwIiwicHVibGlzaGVkX2F0
+        IjoiMjAxNS0wOS0yM1QxNDoyNTo0MC0wNDowMCIsInRlbXBsYXRlX3N1ZmZp
+        eCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6IiIs
+        InZhcmlhbnRzIjpbeyJpZCI6Mjg2MzE2MDUwNTksInByb2R1Y3RfaWQiOjg1
+        OTA4MzAwMTksInRpdGxlIjoiU0tVLTIiLCJwcmljZSI6IjE5Ljk5Iiwic2t1
+        IjoiU0tVLTIiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImludmVudG9yeV9w
+        b2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVsbCwiZnVsZmls
+        bG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9tYW5hZ2VtZW50
+        Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMiIsIm9wdGlvbjIiOm51bGws
+        Im9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjI1
+        OjQwLTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MjU6NDAt
+        MDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxsLCJpbWFnZV9p
+        ZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQiOjAuMCwi
+        d2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRpdHkiOjEs
+        InJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7ImlkIjox
+        MDMxNDM4NTYwMywicHJvZHVjdF9pZCI6ODU5MDgzMDAxOSwibmFtZSI6IlRp
+        dGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMiJdfV0sImltYWdl
+        cyI6W10sImltYWdlIjpudWxsfSx7ImlkIjo4NTkwMjc5NjgzLCJ0aXRsZSI6
+        IlByb2R1Y3QgIzIgLSA4MDk2IiwiYm9keV9odG1sIjoiXHUwMDNjcFx1MDAz
+        ZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9yIjoiRGVm
+        YXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVkX2F0Ijoi
+        MjAxNi0wOS0yM1QxMzo1MTo1Ni0wNDowMCIsImhhbmRsZSI6InByb2R1Y3Qt
+        Mi04MDk2IiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTE6NTctMDQ6
+        MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjUxOjU2LTA0OjAw
+        IiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJn
+        bG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMDMzMTc3
+        OSwicHJvZHVjdF9pZCI6ODU5MDI3OTY4MywidGl0bGUiOiJTS1UtMTUiLCJw
+        cmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTE1IiwicG9zaXRpb24iOjEsImdy
+        YW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRf
+        cHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJp
+        bnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRpb24xIjoiU0tV
+        LTE1Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9h
+        dCI6IjIwMTYtMDktMjNUMTM6NTE6NTYtMDQ6MDAiLCJ1cGRhdGVkX2F0Ijoi
+        MjAxNi0wOS0yM1QxMzo1MTo1Ni0wNDowMCIsInRheGFibGUiOnRydWUsImJh
+        cmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRp
+        dHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2lu
+        dmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9
+        XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNjc4MjExLCJwcm9kdWN0X2lkIjo4
+        NTkwMjc5NjgzLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVz
+        IjpbIlNLVS0xNSJdfV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfSx7Imlk
+        Ijo4NTkwNjU1Mjk5LCJ0aXRsZSI6IlByb2R1Y3QgIzIwIC0gNzE2MiIsImJv
+        ZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRWIVx1MDAzY1wv
+        cFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwicHJvZHVjdF90
+        eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTQ6MTQ6NDItMDQ6
+        MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTIwLTcxNjIiLCJ1cGRhdGVkX2F0Ijoi
+        MjAxNi0wOS0yM1QxNDoxNDo0Mi0wNDowMCIsInB1Ymxpc2hlZF9hdCI6IjIw
+        MTUtMDktMjNUMTQ6MTQ6NDEtMDQ6MDAiLCJ0ZW1wbGF0ZV9zdWZmaXgiOm51
+        bGwsInB1Ymxpc2hlZF9zY29wZSI6Imdsb2JhbCIsInRhZ3MiOiIiLCJ2YXJp
+        YW50cyI6W3siaWQiOjI4NjMxMTQ1NzMxLCJwcm9kdWN0X2lkIjo4NTkwNjU1
+        Mjk5LCJ0aXRsZSI6IlNLVS0zMSIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJT
+        S1UtMzEiLCJwb3NpdGlvbiI6MSwiZ3JhbXMiOjAsImludmVudG9yeV9wb2xp
+        Y3kiOiJkZW55IiwiY29tcGFyZV9hdF9wcmljZSI6bnVsbCwiZnVsZmlsbG1l
+        bnRfc2VydmljZSI6Im1hbnVhbCIsImludmVudG9yeV9tYW5hZ2VtZW50Ijoi
+        c2hvcGlmeSIsIm9wdGlvbjEiOiJTS1UtMzEiLCJvcHRpb24yIjpudWxsLCJv
+        cHRpb24zIjpudWxsLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxNDoxNDo0
+        Mi0wNDowMCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDE0OjE0OjQyLTA0
         OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFyY29kZSI6bnVsbCwiaW1hZ2VfaWQi
         Om51bGwsImludmVudG9yeV9xdWFudGl0eSI6MSwid2VpZ2h0IjowLjAsIndl
         aWdodF91bml0Ijoib3oiLCJvbGRfaW52ZW50b3J5X3F1YW50aXR5IjoxLCJy
         ZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1dLCJvcHRpb25zIjpbeyJpZCI6MTAz
-        MTM3MjQxNjMsInByb2R1Y3RfaWQiOjg1OTAzMTQ0OTksIm5hbWUiOiJUaXRs
-        ZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTMiXX1dLCJpbWFnZXMi
-        OltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDI4MDgzNSwidGl0bGUiOiJQ
-        cm9kdWN0ICM0IC0gMTc5MCIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VB
+        MTQxNTgwODMsInByb2R1Y3RfaWQiOjg1OTA2NTUyOTksIm5hbWUiOiJUaXRs
+        ZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiU0tVLTMxIl19XSwiaW1hZ2Vz
+        IjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAyODAxMzEsInRpdGxlIjoi
+        UHJvZHVjdCAjMyAtIDI2NyIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VB
         cyBzZWVuIG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1
         bHQgVmVuZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIw
-        MTYtMDktMjNUMTM6NTE6NTktMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTQt
-        MTc5MCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUyOjAwLTA0OjAw
-        IiwicHVibGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxMzo1MTo1OS0wNDowMCIs
-        InRlbXBsYXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xv
-        YmFsIiwidGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAzMzQ5MTUs
-        InByb2R1Y3RfaWQiOjg1OTAyODA4MzUsInRpdGxlIjoiUyBcLyBTIFwvIFMi
-        LCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVUy1NXC9TS1VTLTFcL1NLVVMt
-        MlwvU0tVUy0zIiwicG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlf
-        cG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZp
-        bGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVu
-        dCI6bnVsbCwib3B0aW9uMSI6IlMiLCJvcHRpb24yIjoiUyIsIm9wdGlvbjMi
-        OiJTIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTI6MDAtMDQ6MDAi
-        LCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo1MjowMC0wNDowMCIsInRh
-        eGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJp
-        bnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5p
-        dCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNf
-        c2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNjc5Njgz
-        LCJwcm9kdWN0X2lkIjo4NTkwMjgwODM1LCJuYW1lIjoiZm9vLXNpemUtOSIs
-        InBvc2l0aW9uIjoxLCJ2YWx1ZXMiOlsiUyJdfSx7ImlkIjoxMDMxMzY4MDI1
-        OSwicHJvZHVjdF9pZCI6ODU5MDI4MDgzNSwibmFtZSI6ImZvby1zaXplLTEw
-        IiwicG9zaXRpb24iOjIsInZhbHVlcyI6WyJTIl19LHsiaWQiOjEwMzEzNjgw
-        MzIzLCJwcm9kdWN0X2lkIjo4NTkwMjgwODM1LCJuYW1lIjoiZm9vLXNpemUt
-        MTEiLCJwb3NpdGlvbiI6MywidmFsdWVzIjpbIlMiXX1dLCJpbWFnZXMiOltd
-        LCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDI0NzkzOSwidGl0bGUiOiJQcm9k
-        dWN0ICM2IC0gNTA3MCIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBz
-        ZWVuIG9uIFRWIVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQg
-        VmVuZG9yIiwicHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYt
-        MDktMjNUMTM6NTA6MDQtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTYtNTA3
-        MCIsInVwZGF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjUwOjA1LTA0OjAwIiwi
-        cHVibGlzaGVkX2F0IjoiMjAxNS0wOS0yM1QxMzo1MDowNC0wNDowMCIsInRl
-        bXBsYXRlX3N1ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFs
-        IiwidGFncyI6IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAyNjQ4OTksInBy
-        b2R1Y3RfaWQiOjg1OTAyNDc5MzksInRpdGxlIjoiU0tVLTE4IiwicHJpY2Ui
-        OiIxOS45OSIsInNrdSI6IlNLVS0xOCIsInBvc2l0aW9uIjoxLCJncmFtcyI6
-        MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNl
-        IjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50
-        b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0xOCIs
-        Im9wdGlvbjIiOm51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIy
-        MDE2LTA5LTIzVDEzOjUwOjA0LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYt
-        MDktMjNUMTM6NTA6MDQtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2Rl
-        IjpudWxsLCJpbWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5Ijox
-        LCJ3ZWlnaHQiOjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRv
-        cnlfcXVhbnRpdHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9w
-        dGlvbnMiOlt7ImlkIjoxMDMxMzYzNzc2MywicHJvZHVjdF9pZCI6ODU5MDI0
-        NzkzOSwibmFtZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJT
-        S1UtMTgiXX1dLCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5
-        MDE4NDY0MywidGl0bGUiOiJQcm9kdWN0IE5hbWUiLCJib2R5X2h0bWwiOiJc
-        dTAwM2NwXHUwMDNlQXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2UiLCJ2
-        ZW5kb3IiOiJEZWZhdWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIsImNy
-        ZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjQ2OjE2LTA0OjAwIiwiaGFuZGxl
-        IjoicHJvZHVjdC1uYW1lIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NDY6MTYtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjQ2
-        OjE1LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRf
-        c2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoy
-        ODYzMDEwOTU3MSwicHJvZHVjdF9pZCI6ODU5MDE4NDY0MywidGl0bGUiOiJT
-        S1UtMiIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtMiIsInBvc2l0aW9u
-        IjoxLCJncmFtcyI6MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21w
-        YXJlX2F0X3ByaWNlIjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFu
-        dWFsIiwiaW52ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9u
-        MSI6IlNLVS0yIiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3Jl
-        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MTYtMDQ6MDAiLCJ1cGRhdGVk
-        X2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoxNi0wNDowMCIsInRheGFibGUiOnRy
-        dWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlf
-        cXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwi
-        b2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmci
-        OnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNTUyNTc5LCJwcm9kdWN0
-        X2lkIjo4NTkwMTg0NjQzLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwi
-        dmFsdWVzIjpbIlNLVS0yIl19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9
-        LHsiaWQiOjg1OTAxODQ4MzUsInRpdGxlIjoiUHJvZHVjdCBOYW1lIiwiYm9k
-        eV9odG1sIjoiXHUwMDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9w
-        XHUwMDNlIiwidmVuZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5
-        cGUiOiIiLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoxNy0wNDow
-        MCIsImhhbmRsZSI6InByb2R1Y3QtbmFtZS0xIiwidXBkYXRlZF9hdCI6IjIw
-        MTYtMDktMjNUMTM6NDY6MTctMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1
-        LTA5LTIzVDEzOjQ2OjE3LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxs
-        LCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFu
-        dHMiOlt7ImlkIjoyODYzMDEwOTg5MSwicHJvZHVjdF9pZCI6ODU5MDE4NDgz
-        NSwidGl0bGUiOiJTS1UtNCIsInByaWNlIjoiMTkuOTkiLCJza3UiOiJTS1Ut
-        NCIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50b3J5X3BvbGljeSI6
-        ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJmdWxmaWxsbWVudF9z
-        ZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9w
-        aWZ5Iiwib3B0aW9uMSI6IlNLVS00Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9u
-        MyI6bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MTctMDQ6
-        MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoxNy0wNDowMCIs
-        InRheGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxs
-        LCJpbnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRf
-        dW5pdCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWly
-        ZXNfc2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNTUy
-        OTYzLCJwcm9kdWN0X2lkIjo4NTkwMTg0ODM1LCJuYW1lIjoiVGl0bGUiLCJw
-        b3NpdGlvbiI6MSwidmFsdWVzIjpbIlNLVS00Il19XSwiaW1hZ2VzIjpbXSwi
-        aW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAxODUyODMsInRpdGxlIjoiUHJvZHVj
-        dCBOYW1lIiwiYm9keV9odG1sIjoiXHUwMDNjcFx1MDAzZUFzIHNlZW4gb24g
-        VFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9yIjoiRGVmYXVsdCBWZW5kb3Ii
-        LCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1Qx
-        Mzo0NjoxOC0wNDowMCIsImhhbmRsZSI6InByb2R1Y3QtbmFtZS0yIiwidXBk
-        YXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MTgtMDQ6MDAiLCJwdWJsaXNo
-        ZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjQ2OjE3LTA0OjAwIiwidGVtcGxhdGVf
-        c3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdz
-        IjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMDExMTA0MywicHJvZHVjdF9p
-        ZCI6ODU5MDE4NTI4MywidGl0bGUiOiJTS1UtNiIsInByaWNlIjoiMTkuOTki
-        LCJza3UiOiJTS1UtNiIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50
-        b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJm
-        dWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFn
-        ZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS02Iiwib3B0aW9uMiI6
-        bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNU
-        MTM6NDY6MTgtMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0
-        NjoxOC0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImlt
-        YWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6
-        MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0
-        eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3si
-        aWQiOjEwMzEzNTUzNTM5LCJwcm9kdWN0X2lkIjo4NTkwMTg1MjgzLCJuYW1l
-        IjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpbIlNLVS02Il19XSwi
-        aW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1OTAxODU2NjcsInRp
-        dGxlIjoiUHJvZHVjdCBOYW1lIiwiYm9keV9odG1sIjoiXHUwMDNjcFx1MDAz
-        ZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwidmVuZG9yIjoiRGVm
-        YXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJjcmVhdGVkX2F0Ijoi
-        MjAxNi0wOS0yM1QxMzo0NjoxOS0wNDowMCIsImhhbmRsZSI6InByb2R1Y3Qt
-        bmFtZS0zIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MTktMDQ6
-        MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjQ2OjE4LTA0OjAw
-        IiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJn
-        bG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMDExMTYx
-        OSwicHJvZHVjdF9pZCI6ODU5MDE4NTY2NywidGl0bGUiOiJTS1UtOCIsInBy
-        aWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtOCIsInBvc2l0aW9uIjoxLCJncmFt
-        cyI6MCwiaW52ZW50b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3By
-        aWNlIjpudWxsLCJmdWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52
-        ZW50b3J5X21hbmFnZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS04
+        MTYtMDktMjNUMTM6NTE6NTctMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LTMt
+        MjY3IiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NTE6NTgtMDQ6MDAi
+        LCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEzOjUxOjU3LTA0OjAwIiwi
+        dGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNoZWRfc2NvcGUiOiJnbG9i
+        YWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7ImlkIjoyODYzMDMzMzI1MSwi
+        cHJvZHVjdF9pZCI6ODU5MDI4MDEzMSwidGl0bGUiOiJTS1UtMTYiLCJwcmlj
+        ZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTE2IiwicG9zaXRpb24iOjEsImdyYW1z
+        IjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIsImNvbXBhcmVfYXRfcHJp
+        Y2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2UiOiJtYW51YWwiLCJpbnZl
+        bnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJvcHRpb24xIjoiU0tVLTE2
         Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVsbCwiY3JlYXRlZF9hdCI6
-        IjIwMTYtMDktMjNUMTM6NDY6MTktMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAx
-        Ni0wOS0yM1QxMzo0NjoxOS0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNv
+        IjIwMTYtMDktMjNUMTM6NTE6NTctMDQ6MDAiLCJ1cGRhdGVkX2F0IjoiMjAx
+        Ni0wOS0yM1QxMzo1MTo1Ny0wNDowMCIsInRheGFibGUiOnRydWUsImJhcmNv
         ZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZlbnRvcnlfcXVhbnRpdHki
         OjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6Im96Iiwib2xkX2ludmVu
         dG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hpcHBpbmciOnRydWV9XSwi
-        b3B0aW9ucyI6W3siaWQiOjEwMzEzNTUzOTg3LCJwcm9kdWN0X2lkIjo4NTkw
-        MTg1NjY3LCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpb
-        IlNLVS04Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQiOjg1
-        OTAxODU4NTksInRpdGxlIjoiUHJvZHVjdCBOYW1lIiwiYm9keV9odG1sIjoi
-        XHUwMDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNlIiwi
-        dmVuZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIiLCJj
-        cmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoyMC0wNDowMCIsImhhbmRs
-        ZSI6InByb2R1Y3QtbmFtZS00IiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNU
-        MTM6NDY6MjAtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIzVDEz
-        OjQ2OjE5LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJsaXNo
-        ZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7Imlk
-        IjoyODYzMDExMTg3NSwicHJvZHVjdF9pZCI6ODU5MDE4NTg1OSwidGl0bGUi
-        OiJTS1UtMTAiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTEwIiwicG9z
-        aXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVueSIs
-        ImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZpY2Ui
-        OiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnkiLCJv
-        cHRpb24xIjoiU0tVLTEwIiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6bnVs
-        bCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MjAtMDQ6MDAiLCJ1
-        cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoyMC0wNDowMCIsInRheGFi
-        bGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJpbnZl
-        bnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5pdCI6
-        Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNfc2hp
-        cHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNTU0MjQzLCJw
-        cm9kdWN0X2lkIjo4NTkwMTg1ODU5LCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlv
-        biI6MSwidmFsdWVzIjpbIlNLVS0xMCJdfV0sImltYWdlcyI6W10sImltYWdl
-        IjpudWxsfSx7ImlkIjo4NTkwMTg3MDc1LCJ0aXRsZSI6IlByb2R1Y3QgTmFt
-        ZSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRWIVx1
-        MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwicHJv
-        ZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6
-        MjQtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LW5hbWUtNSIsInVwZGF0ZWRf
-        YXQiOiIyMDE2LTA5LTIzVDEzOjQ2OjI0LTA0OjAwIiwicHVibGlzaGVkX2F0
-        IjoiMjAxNS0wOS0yM1QxMzo0NjoyMy0wNDowMCIsInRlbXBsYXRlX3N1ZmZp
-        eCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6IiIs
-        InZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAxMTQzMDcsInByb2R1Y3RfaWQiOjg1
-        OTAxODcwNzUsInRpdGxlIjoiU0tVLTE3IiwicHJpY2UiOiIxOS45OSIsInNr
-        dSI6IlNLVS0xNyIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50b3J5
-        X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJmdWxm
-        aWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFnZW1l
-        bnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0xNyIsIm9wdGlvbjIiOm51
-        bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIzVDEz
-        OjQ2OjI0LTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6
-        MjQtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxsLCJpbWFn
-        ZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQiOjAu
-        MCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRpdHki
-        OjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7Imlk
-        IjoxMDMxMzU1NjAzNSwicHJvZHVjdF9pZCI6ODU5MDE4NzA3NSwibmFtZSI6
-        IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMTciXX1dLCJp
-        bWFnZXMiOltdLCJpbWFnZSI6bnVsbH0seyJpZCI6ODU5MDE4NzI2NywidGl0
-        bGUiOiJQcm9kdWN0IE5hbWUiLCJib2R5X2h0bWwiOiJcdTAwM2NwXHUwMDNl
-        QXMgc2VlbiBvbiBUViFcdTAwM2NcL3BcdTAwM2UiLCJ2ZW5kb3IiOiJEZWZh
-        dWx0IFZlbmRvciIsInByb2R1Y3RfdHlwZSI6IiIsImNyZWF0ZWRfYXQiOiIy
-        MDE2LTA5LTIzVDEzOjQ2OjI1LTA0OjAwIiwiaGFuZGxlIjoicHJvZHVjdC1u
-        YW1lLTYiLCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjoyNS0wNDow
-        MCIsInB1Ymxpc2hlZF9hdCI6IjIwMTUtMDktMjNUMTM6NDY6MjQtMDQ6MDAi
-        LCJ0ZW1wbGF0ZV9zdWZmaXgiOm51bGwsInB1Ymxpc2hlZF9zY29wZSI6Imds
-        b2JhbCIsInRhZ3MiOiIiLCJ2YXJpYW50cyI6W3siaWQiOjI4NjMwMTE0NzU1
-        LCJwcm9kdWN0X2lkIjo4NTkwMTg3MjY3LCJ0aXRsZSI6IlNLVS0xOSIsInBy
-        aWNlIjoiMTkuOTkiLCJza3UiOiJTS1UtMTkiLCJwb3NpdGlvbiI6MSwiZ3Jh
-        bXMiOjAsImludmVudG9yeV9wb2xpY3kiOiJkZW55IiwiY29tcGFyZV9hdF9w
-        cmljZSI6bnVsbCwiZnVsZmlsbG1lbnRfc2VydmljZSI6Im1hbnVhbCIsImlu
-        dmVudG9yeV9tYW5hZ2VtZW50Ijoic2hvcGlmeSIsIm9wdGlvbjEiOiJTS1Ut
-        MTkiLCJvcHRpb24yIjpudWxsLCJvcHRpb24zIjpudWxsLCJjcmVhdGVkX2F0
-        IjoiMjAxNi0wOS0yM1QxMzo0NjoyNS0wNDowMCIsInVwZGF0ZWRfYXQiOiIy
-        MDE2LTA5LTIzVDEzOjQ2OjI1LTA0OjAwIiwidGF4YWJsZSI6dHJ1ZSwiYmFy
-        Y29kZSI6bnVsbCwiaW1hZ2VfaWQiOm51bGwsImludmVudG9yeV9xdWFudGl0
-        eSI6MSwid2VpZ2h0IjowLjAsIndlaWdodF91bml0Ijoib3oiLCJvbGRfaW52
-        ZW50b3J5X3F1YW50aXR5IjoxLCJyZXF1aXJlc19zaGlwcGluZyI6dHJ1ZX1d
-        LCJvcHRpb25zIjpbeyJpZCI6MTAzMTM1NTYyOTEsInByb2R1Y3RfaWQiOjg1
-        OTAxODcyNjcsIm5hbWUiOiJUaXRsZSIsInBvc2l0aW9uIjoxLCJ2YWx1ZXMi
-        OlsiU0tVLTE5Il19XSwiaW1hZ2VzIjpbXSwiaW1hZ2UiOm51bGx9LHsiaWQi
-        Ojg1OTAxODg2MTEsInRpdGxlIjoiUHJvZHVjdCBOYW1lIiwiYm9keV9odG1s
-        IjoiXHUwMDNjcFx1MDAzZUFzIHNlZW4gb24gVFYhXHUwMDNjXC9wXHUwMDNl
-        IiwidmVuZG9yIjoiRGVmYXVsdCBWZW5kb3IiLCJwcm9kdWN0X3R5cGUiOiIi
-        LCJjcmVhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjozMC0wNDowMCIsImhh
-        bmRsZSI6InByb2R1Y3QtbmFtZS03IiwidXBkYXRlZF9hdCI6IjIwMTYtMDkt
-        MjNUMTM6NDY6MzAtMDQ6MDAiLCJwdWJsaXNoZWRfYXQiOiIyMDE1LTA5LTIz
-        VDEzOjQ2OjI5LTA0OjAwIiwidGVtcGxhdGVfc3VmZml4IjpudWxsLCJwdWJs
-        aXNoZWRfc2NvcGUiOiJnbG9iYWwiLCJ0YWdzIjoiIiwidmFyaWFudHMiOlt7
-        ImlkIjoyODYzMDExNjkzMSwicHJvZHVjdF9pZCI6ODU5MDE4ODYxMSwidGl0
-        bGUiOiJTS1UtMjkiLCJwcmljZSI6IjE5Ljk5Iiwic2t1IjoiU0tVLTI5Iiwi
-        cG9zaXRpb24iOjEsImdyYW1zIjowLCJpbnZlbnRvcnlfcG9saWN5IjoiZGVu
-        eSIsImNvbXBhcmVfYXRfcHJpY2UiOm51bGwsImZ1bGZpbGxtZW50X3NlcnZp
-        Y2UiOiJtYW51YWwiLCJpbnZlbnRvcnlfbWFuYWdlbWVudCI6InNob3BpZnki
-        LCJvcHRpb24xIjoiU0tVLTI5Iiwib3B0aW9uMiI6bnVsbCwib3B0aW9uMyI6
-        bnVsbCwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6NDY6MzAtMDQ6MDAi
-        LCJ1cGRhdGVkX2F0IjoiMjAxNi0wOS0yM1QxMzo0NjozMC0wNDowMCIsInRh
-        eGFibGUiOnRydWUsImJhcmNvZGUiOm51bGwsImltYWdlX2lkIjpudWxsLCJp
-        bnZlbnRvcnlfcXVhbnRpdHkiOjEsIndlaWdodCI6MC4wLCJ3ZWlnaHRfdW5p
-        dCI6Im96Iiwib2xkX2ludmVudG9yeV9xdWFudGl0eSI6MSwicmVxdWlyZXNf
-        c2hpcHBpbmciOnRydWV9XSwib3B0aW9ucyI6W3siaWQiOjEwMzEzNTU4MDE5
-        LCJwcm9kdWN0X2lkIjo4NTkwMTg4NjExLCJuYW1lIjoiVGl0bGUiLCJwb3Np
-        dGlvbiI6MSwidmFsdWVzIjpbIlNLVS0yOSJdfV0sImltYWdlcyI6W10sImlt
-        YWdlIjpudWxsfSx7ImlkIjo4NTkwMTg4ODY3LCJ0aXRsZSI6IlByb2R1Y3Qg
-        TmFtZSIsImJvZHlfaHRtbCI6Ilx1MDAzY3BcdTAwM2VBcyBzZWVuIG9uIFRW
-        IVx1MDAzY1wvcFx1MDAzZSIsInZlbmRvciI6IkRlZmF1bHQgVmVuZG9yIiwi
-        cHJvZHVjdF90eXBlIjoiIiwiY3JlYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NDY6MzEtMDQ6MDAiLCJoYW5kbGUiOiJwcm9kdWN0LW5hbWUtOCIsInVwZGF0
-        ZWRfYXQiOiIyMDE2LTA5LTIzVDEzOjQ2OjMxLTA0OjAwIiwicHVibGlzaGVk
-        X2F0IjoiMjAxNS0wOS0yM1QxMzo0NjozMC0wNDowMCIsInRlbXBsYXRlX3N1
-        ZmZpeCI6bnVsbCwicHVibGlzaGVkX3Njb3BlIjoiZ2xvYmFsIiwidGFncyI6
-        IiIsInZhcmlhbnRzIjpbeyJpZCI6Mjg2MzAxMTczMTUsInByb2R1Y3RfaWQi
-        Ojg1OTAxODg4NjcsInRpdGxlIjoiU0tVLTMxIiwicHJpY2UiOiIxOS45OSIs
-        InNrdSI6IlNLVS0zMSIsInBvc2l0aW9uIjoxLCJncmFtcyI6MCwiaW52ZW50
-        b3J5X3BvbGljeSI6ImRlbnkiLCJjb21wYXJlX2F0X3ByaWNlIjpudWxsLCJm
-        dWxmaWxsbWVudF9zZXJ2aWNlIjoibWFudWFsIiwiaW52ZW50b3J5X21hbmFn
-        ZW1lbnQiOiJzaG9waWZ5Iiwib3B0aW9uMSI6IlNLVS0zMSIsIm9wdGlvbjIi
-        Om51bGwsIm9wdGlvbjMiOm51bGwsImNyZWF0ZWRfYXQiOiIyMDE2LTA5LTIz
-        VDEzOjQ2OjMxLTA0OjAwIiwidXBkYXRlZF9hdCI6IjIwMTYtMDktMjNUMTM6
-        NDY6MzEtMDQ6MDAiLCJ0YXhhYmxlIjp0cnVlLCJiYXJjb2RlIjpudWxsLCJp
-        bWFnZV9pZCI6bnVsbCwiaW52ZW50b3J5X3F1YW50aXR5IjoxLCJ3ZWlnaHQi
-        OjAuMCwid2VpZ2h0X3VuaXQiOiJveiIsIm9sZF9pbnZlbnRvcnlfcXVhbnRp
-        dHkiOjEsInJlcXVpcmVzX3NoaXBwaW5nIjp0cnVlfV0sIm9wdGlvbnMiOlt7
-        ImlkIjoxMDMxMzU1ODQwMywicHJvZHVjdF9pZCI6ODU5MDE4ODg2NywibmFt
-        ZSI6IlRpdGxlIiwicG9zaXRpb24iOjEsInZhbHVlcyI6WyJTS1UtMzEiXX1d
-        LCJpbWFnZXMiOltdLCJpbWFnZSI6bnVsbH1dfQ==
+        b3B0aW9ucyI6W3siaWQiOjEwMzEzNjc4Nzg3LCJwcm9kdWN0X2lkIjo4NTkw
+        MjgwMTMxLCJuYW1lIjoiVGl0bGUiLCJwb3NpdGlvbiI6MSwidmFsdWVzIjpb
+        IlNLVS0xNiJdfV0sImltYWdlcyI6W10sImltYWdlIjpudWxsfV19
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:07 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:07 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590643139.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922883.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8032,7 +8026,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:07 GMT
+      - Fri, 23 Sep 2016 19:47:07 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -8048,9 +8042,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 19/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 19/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -8058,9 +8052,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/92d66531-7916-45f8-bf10-a91de99e0c33?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8bf90c0f-966f-4f50-9517-181cf70ec15c?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 92d66531-7916-45f8-bf10-a91de99e0c33
+      - 8bf90c0f-966f-4f50-9517-181cf70ec15c
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -8074,13 +8068,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590643139,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:06-04:00","published_at":"2015-09-23T14:14:04-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631113603,"product_id":8590643139,"title":"SKU-8","price":"19.99","sku":"SKU-8","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-8","option2":null,"option3":null,"created_at":"2016-09-23T14:14:05-04:00","updated_at":"2016-09-23T14:14:05-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314142979,"product_id":8590643139,"name":"Title","position":1,"values":["SKU-8"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922883,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:04-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:06-04:00","published_at":"2015-09-23T15:47:02-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634458051,"product_id":8591922883,"title":"SKU-15","price":"19.99","sku":"SKU-15","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-15","option2":null,"option3":null,"created_at":"2016-09-23T15:47:04-04:00","updated_at":"2016-09-23T15:47:04-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862531,"product_id":8591922883,"name":"Title","position":1,"values":["SKU-15"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:07 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:07 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590643139.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922883.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8101,7 +8095,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:07 GMT
+      - Fri, 23 Sep 2016 19:47:07 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -8117,9 +8111,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 19/40
+      - 13/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 19/40
+      - 13/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -8129,9 +8123,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c9459638-719b-4daf-a8ce-a97b1ec9a953?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/e602064a-c64a-426b-b896-243a00945ff9?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - c9459638-719b-4daf-a8ce-a97b1ec9a953
+      - e602064a-c64a-426b-b896-243a00945ff9
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -8147,5 +8141,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:07 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_already_exists_on_Shopify/updates_the_existing_product.yml
+++ b/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_already_exists_on_Shopify/updates_the_existing_product.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:01 GMT
+      - Fri, 23 Sep 2016 19:46:59 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 10/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 10/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/25c8af45-cfb3-4017-ba0c-1632e69c5a51?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/fe7891ac-d295-44d7-a8c7-3ab8c04e5dd4?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 25c8af45-cfb3-4017-ba0c-1632e69c5a51
+      - fe7891ac-d295-44d7-a8c7-3ab8c04e5dd4
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,7 +64,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:01 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:59 GMT
 - request:
     method: get
     uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
@@ -88,7 +88,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:01 GMT
+      - Fri, 23 Sep 2016 19:46:59 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -104,9 +104,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 10/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 10/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -114,9 +114,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/a1bb4578-4ba1-4965-928d-1fa06e4572a8?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/5412af9f-64a3-4c78-bb25-b3daf23eab5e?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - a1bb4578-4ba1-4965-928d-1fa06e4572a8
+      - 5412af9f-64a3-4c78-bb25-b3daf23eab5e
       X-Dc:
       - ash
       X-Download-Options:
@@ -129,15 +129,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:01 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:59 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:01.494Z","updated_at":"2016-09-23T18:14:01.518Z","published_at":"2015-09-23T18:14:01.445Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-7","inventory_management":"shopify","updated_at":"2016-09-23T18:14:01.510Z","option1":"SKU-7"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:46:59.579Z","updated_at":"2016-09-23T19:46:59.598Z","published_at":"2015-09-23T19:46:59.554Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-14","inventory_management":"shopify","updated_at":"2016-09-23T19:46:59.593Z","option1":"SKU-14"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -157,7 +157,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:02 GMT
+      - Fri, 23 Sep 2016 19:47:00 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -171,9 +171,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 11/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 11/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -181,11 +181,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590642243
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591922435
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/35ec0a32-d2c5-4522-9ac0-8bcd214dc759?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/de5863d7-54c0-488e-a297-c7cb5a51c348?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 35ec0a32-d2c5-4522-9ac0-8bcd214dc759
+      - de5863d7-54c0-488e-a297-c7cb5a51c348
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -199,13 +199,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590642243,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:02-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:02-04:00","published_at":"2015-09-23T14:14:01-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631107267,"product_id":8590642243,"title":"SKU-7","price":"19.99","sku":"SKU-7","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-7","option2":null,"option3":null,"created_at":"2016-09-23T14:14:02-04:00","updated_at":"2016-09-23T14:14:02-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314141827,"product_id":8590642243,"name":"Title","position":1,"values":["SKU-7"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922435,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:00-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:00-04:00","published_at":"2015-09-23T15:46:59-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634456515,"product_id":8591922435,"title":"SKU-14","price":"19.99","sku":"SKU-14","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-14","option2":null,"option3":null,"created_at":"2016-09-23T15:47:00-04:00","updated_at":"2016-09-23T15:47:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861827,"product_id":8591922435,"name":"Title","position":1,"values":["SKU-14"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:02 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:00 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590642243.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922435.json
     body:
       encoding: US-ASCII
       string: ''
@@ -226,7 +226,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:02 GMT
+      - Fri, 23 Sep 2016 19:47:00 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -242,9 +242,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 11/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 11/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -252,9 +252,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/6b511fe8-9549-4def-ae16-73eafac23db2?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/499a7daf-08f1-45b0-ad18-c4aaba829fef?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 6b511fe8-9549-4def-ae16-73eafac23db2
+      - 499a7daf-08f1-45b0-ad18-c4aaba829fef
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -268,17 +268,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590642243,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:02-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:02-04:00","published_at":"2015-09-23T14:14:01-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631107267,"product_id":8590642243,"title":"SKU-7","price":"19.99","sku":"SKU-7","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-7","option2":null,"option3":null,"created_at":"2016-09-23T14:14:02-04:00","updated_at":"2016-09-23T14:14:02-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314141827,"product_id":8590642243,"name":"Title","position":1,"values":["SKU-7"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922435,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:00-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:00-04:00","published_at":"2015-09-23T15:46:59-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634456515,"product_id":8591922435,"title":"SKU-14","price":"19.99","sku":"SKU-14","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-14","option2":null,"option3":null,"created_at":"2016-09-23T15:47:00-04:00","updated_at":"2016-09-23T15:47:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861827,"product_id":8591922435,"name":"Title","position":1,"values":["SKU-14"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:02 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:00 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590642243.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922435.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590642243,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:01.494Z","handle":"product-name","updated_at":"2016-09-23T18:14:01.518Z","published_at":"2015-09-23T18:14:01.445Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631107267,"title":"SKU-7","price":"19.99","sku":"SKU-7","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-7","option2":null,"option3":null,"created_at":"2016-09-23T14:14:02-04:00","updated_at":"2016-09-23T14:14:02-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314141827,"product_id":8590642243,"name":"Title","position":1,"values":["SKU-7"]}],"images":[{"variant_ids":["28631107267"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591922435,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:46:59.579Z","handle":"product-name","updated_at":"2016-09-23T19:46:59.598Z","published_at":"2015-09-23T19:46:59.554Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634456515,"title":"SKU-14","price":"19.99","sku":"SKU-14","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-14","option2":null,"option3":null,"created_at":"2016-09-23T15:47:00-04:00","updated_at":"2016-09-23T15:47:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861827,"product_id":8591922435,"name":"Title","position":1,"values":["SKU-14"]}],"images":[{"variant_ids":["28634456515"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -298,7 +298,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:03 GMT
+      - Fri, 23 Sep 2016 19:47:01 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -314,9 +314,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 11/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 11/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -324,11 +324,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590642243
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591922435
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/23f7e0a6-2ce4-4083-9fa0-6388e6dbe8bd?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/f8cb140b-c288-4d6c-a936-e82156544c49?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 23f7e0a6-2ce4-4083-9fa0-6388e6dbe8bd
+      - f8cb140b-c288-4d6c-a936-e82156544c49
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -342,13 +342,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590642243,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:02-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:03-04:00","published_at":"2015-09-23T14:14:01-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631107267,"product_id":8590642243,"title":"SKU-7","price":"19.99","sku":"SKU-7","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-7","option2":null,"option3":null,"created_at":"2016-09-23T14:14:02-04:00","updated_at":"2016-09-23T14:14:02-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314141827,"product_id":8590642243,"name":"Title","position":1,"values":["SKU-7"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922435,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:00-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:01-04:00","published_at":"2015-09-23T15:46:59-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634456515,"product_id":8591922435,"title":"SKU-14","price":"19.99","sku":"SKU-14","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-14","option2":null,"option3":null,"created_at":"2016-09-23T15:47:00-04:00","updated_at":"2016-09-23T15:47:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861827,"product_id":8591922435,"name":"Title","position":1,"values":["SKU-14"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:03 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:01 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590642243.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922435.json
     body:
       encoding: US-ASCII
       string: ''
@@ -369,7 +369,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:03 GMT
+      - Fri, 23 Sep 2016 19:47:01 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -385,9 +385,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 11/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 11/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -395,9 +395,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/502fd5c1-64b0-46e4-a262-4209fec724bf?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8272c4ec-332a-433c-9869-ade723da4413?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 502fd5c1-64b0-46e4-a262-4209fec724bf
+      - 8272c4ec-332a-433c-9869-ade723da4413
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -411,17 +411,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590642243,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:02-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:03-04:00","published_at":"2015-09-23T14:14:01-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631107267,"product_id":8590642243,"title":"SKU-7","price":"19.99","sku":"SKU-7","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-7","option2":null,"option3":null,"created_at":"2016-09-23T14:14:02-04:00","updated_at":"2016-09-23T14:14:02-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314141827,"product_id":8590642243,"name":"Title","position":1,"values":["SKU-7"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922435,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:00-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:01-04:00","published_at":"2015-09-23T15:46:59-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634456515,"product_id":8591922435,"title":"SKU-14","price":"19.99","sku":"SKU-14","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-14","option2":null,"option3":null,"created_at":"2016-09-23T15:47:00-04:00","updated_at":"2016-09-23T15:47:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861827,"product_id":8591922435,"name":"Title","position":1,"values":["SKU-14"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:03 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:01 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590642243.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922435.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590642243,"title":"new_name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:01.494Z","handle":"product-name","updated_at":"2016-09-23T18:14:03.326Z","published_at":"2015-09-23T18:14:01.445Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631107267,"title":"SKU-7","price":"19.99","sku":"SKU-7","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-7","option2":null,"option3":null,"created_at":"2016-09-23T14:14:02-04:00","updated_at":"2016-09-23T14:14:02-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314141827,"product_id":8590642243,"name":"Title","position":1,"values":["SKU-7"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922435,"title":"new_name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:46:59.579Z","handle":"product-name","updated_at":"2016-09-23T19:47:01.277Z","published_at":"2015-09-23T19:46:59.554Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634456515,"title":"SKU-14","price":"19.99","sku":"SKU-14","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-14","option2":null,"option3":null,"created_at":"2016-09-23T15:47:00-04:00","updated_at":"2016-09-23T15:47:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861827,"product_id":8591922435,"name":"Title","position":1,"values":["SKU-14"]}],"images":[],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -441,7 +441,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:03 GMT
+      - Fri, 23 Sep 2016 19:47:01 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -457,9 +457,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 15/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 15/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -467,11 +467,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590642243
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591922435
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/044a3282-bbed-46a2-a921-9f1cad619a87?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/2aca9873-b77b-455f-98a6-46b636b40604?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 044a3282-bbed-46a2-a921-9f1cad619a87
+      - 2aca9873-b77b-455f-98a6-46b636b40604
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -485,13 +485,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590642243,"title":"new_name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:02-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:03-04:00","published_at":"2015-09-23T14:14:01-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631107267,"product_id":8590642243,"title":"SKU-7","price":"19.99","sku":"SKU-7","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-7","option2":null,"option3":null,"created_at":"2016-09-23T14:14:02-04:00","updated_at":"2016-09-23T14:14:02-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314141827,"product_id":8590642243,"name":"Title","position":1,"values":["SKU-7"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922435,"title":"new_name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:00-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:01-04:00","published_at":"2015-09-23T15:46:59-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634456515,"product_id":8591922435,"title":"SKU-14","price":"19.99","sku":"SKU-14","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-14","option2":null,"option3":null,"created_at":"2016-09-23T15:47:00-04:00","updated_at":"2016-09-23T15:47:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861827,"product_id":8591922435,"name":"Title","position":1,"values":["SKU-14"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:03 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:01 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590642243.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922435.json
     body:
       encoding: US-ASCII
       string: ''
@@ -512,7 +512,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:04 GMT
+      - Fri, 23 Sep 2016 19:47:01 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -528,9 +528,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 15/40
+      - 12/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 15/40
+      - 12/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -538,9 +538,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/b5cf18f6-1158-45d1-a724-8b5aa7f6de84?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b70c8cbe-9da7-4da0-bae1-0a9ddc1df4b1?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - b5cf18f6-1158-45d1-a724-8b5aa7f6de84
+      - b70c8cbe-9da7-4da0-bae1-0a9ddc1df4b1
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -554,13 +554,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590642243,"title":"new_name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:02-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:03-04:00","published_at":"2015-09-23T14:14:01-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631107267,"product_id":8590642243,"title":"SKU-7","price":"19.99","sku":"SKU-7","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-7","option2":null,"option3":null,"created_at":"2016-09-23T14:14:02-04:00","updated_at":"2016-09-23T14:14:02-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314141827,"product_id":8590642243,"name":"Title","position":1,"values":["SKU-7"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591922435,"title":"new_name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:00-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:01-04:00","published_at":"2015-09-23T15:46:59-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634456515,"product_id":8591922435,"title":"SKU-14","price":"19.99","sku":"SKU-14","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-14","option2":null,"option3":null,"created_at":"2016-09-23T15:47:00-04:00","updated_at":"2016-09-23T15:47:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861827,"product_id":8591922435,"name":"Title","position":1,"values":["SKU-14"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:04 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:01 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590642243.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591922435.json
     body:
       encoding: US-ASCII
       string: ''
@@ -581,7 +581,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:04 GMT
+      - Fri, 23 Sep 2016 19:47:02 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -597,9 +597,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 16/40
+      - 13/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 16/40
+      - 13/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -609,9 +609,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/bcf5e6d1-0c35-44dd-882a-bb1050e4ed72?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/375ba755-53d3-45ed-a987-aeb2c079ed0d?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - bcf5e6d1-0c35-44dd-882a-bb1050e4ed72
+      - 375ba755-53d3-45ed-a987-aeb2c079ed0d
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -627,5 +627,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:04 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:02 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_does_not_exists_on_Shopify/creates_a_new_product.yml
+++ b/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_does_not_exists_on_Shopify/creates_a_new_product.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:12 GMT
+      - Fri, 23 Sep 2016 19:47:15 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 24/40
+      - 18/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 24/40
+      - 18/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/15d306f5-a101-4fd9-9605-e4f7b5ee7b2e?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/e03ae320-5e53-4581-b12b-518c91d636b7?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 15d306f5-a101-4fd9-9605-e4f7b5ee7b2e
+      - e03ae320-5e53-4581-b12b-518c91d636b7
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,7 +64,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:12 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:15 GMT
 - request:
     method: get
     uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
@@ -88,7 +88,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:12 GMT
+      - Fri, 23 Sep 2016 19:47:15 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -104,9 +104,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 24/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 24/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -114,9 +114,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/7a818205-3b8a-4b49-aa99-37bac3623e70?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8c6221d0-f6f3-4b4f-9269-cd1aec586e25?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 7a818205-3b8a-4b49-aa99-37bac3623e70
+      - 8c6221d0-f6f3-4b4f-9269-cd1aec586e25
       X-Dc:
       - ash
       X-Download-Options:
@@ -129,15 +129,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:12 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:15 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:12.545Z","updated_at":"2016-09-23T18:14:12.586Z","published_at":"2015-09-23T18:14:12.508Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"master-sku","inventory_management":"shopify","updated_at":"2016-09-23T18:14:12.583Z","option1":"master-sku"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:47:14.990Z","updated_at":"2016-09-23T19:47:15.025Z","published_at":"2015-09-23T19:47:14.962Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"master-sku","inventory_management":"shopify","updated_at":"2016-09-23T19:47:15.023Z","option1":"master-sku"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -157,7 +157,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:13 GMT
+      - Fri, 23 Sep 2016 19:47:15 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -171,9 +171,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -181,11 +181,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590645891
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591924099
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/06c711fc-964b-487c-aaf9-7b8a0a5b63c9?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b1dcfc42-d970-40af-bf75-988cc581fb45?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 06c711fc-964b-487c-aaf9-7b8a0a5b63c9
+      - b1dcfc42-d970-40af-bf75-988cc581fb45
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -199,13 +199,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590645891,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:13-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:13-04:00","published_at":"2015-09-23T14:14:12-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631122307,"product_id":8590645891,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:13-04:00","updated_at":"2016-09-23T14:14:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314146435,"product_id":8590645891,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591924099,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:15-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:15-04:00","published_at":"2015-09-23T15:47:14-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634463427,"product_id":8591924099,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:15-04:00","updated_at":"2016-09-23T15:47:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315864131,"product_id":8591924099,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:13 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:16 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590645891.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591924099.json
     body:
       encoding: US-ASCII
       string: ''
@@ -226,7 +226,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:13 GMT
+      - Fri, 23 Sep 2016 19:47:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -242,9 +242,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -252,9 +252,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/4e493341-2ee2-40b4-99e1-780a99d4c147?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/10ff94a0-0ba5-4c4e-ac61-dead4b294104?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 4e493341-2ee2-40b4-99e1-780a99d4c147
+      - 10ff94a0-0ba5-4c4e-ac61-dead4b294104
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -268,17 +268,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590645891,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:13-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:13-04:00","published_at":"2015-09-23T14:14:12-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631122307,"product_id":8590645891,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:13-04:00","updated_at":"2016-09-23T14:14:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314146435,"product_id":8590645891,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591924099,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:15-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:15-04:00","published_at":"2015-09-23T15:47:14-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634463427,"product_id":8591924099,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:15-04:00","updated_at":"2016-09-23T15:47:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315864131,"product_id":8591924099,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:13 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:16 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590645891.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591924099.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590645891,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:12.545Z","handle":"product-name","updated_at":"2016-09-23T18:14:12.586Z","published_at":"2015-09-23T18:14:12.508Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631122307,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:13-04:00","updated_at":"2016-09-23T14:14:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314146435,"product_id":8590645891,"name":"Title","position":1,"values":["master-sku"]}],"images":[{"variant_ids":["28631122307"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591924099,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:47:14.990Z","handle":"product-name","updated_at":"2016-09-23T19:47:15.025Z","published_at":"2015-09-23T19:47:14.962Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634463427,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:15-04:00","updated_at":"2016-09-23T15:47:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315864131,"product_id":8591924099,"name":"Title","position":1,"values":["master-sku"]}],"images":[{"variant_ids":["28634463427"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -298,7 +298,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:13 GMT
+      - Fri, 23 Sep 2016 19:47:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -314,9 +314,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 25/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -324,11 +324,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590645891
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591924099
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ee960d3b-3549-4a2f-8841-c9aeb119e712?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/ea7a2e12-70a9-4dcc-ab53-03d7b644d10d?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - ee960d3b-3549-4a2f-8841-c9aeb119e712
+      - ea7a2e12-70a9-4dcc-ab53-03d7b644d10d
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -342,13 +342,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590645891,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:13-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:13-04:00","published_at":"2015-09-23T14:14:12-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631122307,"product_id":8590645891,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:13-04:00","updated_at":"2016-09-23T14:14:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314146435,"product_id":8590645891,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591924099,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:15-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:16-04:00","published_at":"2015-09-23T15:47:14-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634463427,"product_id":8591924099,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:15-04:00","updated_at":"2016-09-23T15:47:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315864131,"product_id":8591924099,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:13 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:16 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590645891.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591924099.json
     body:
       encoding: US-ASCII
       string: ''
@@ -369,7 +369,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:14 GMT
+      - Fri, 23 Sep 2016 19:47:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -385,9 +385,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
+      - 19/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
+      - 19/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -395,9 +395,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/9dcee184-57bd-46b4-af19-ccc1bd58d398?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/d11cdc4c-adbd-4cfb-8537-e3a982e652b3?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 9dcee184-57bd-46b4-af19-ccc1bd58d398
+      - d11cdc4c-adbd-4cfb-8537-e3a982e652b3
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -411,13 +411,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590645891,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:13-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:13-04:00","published_at":"2015-09-23T14:14:12-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631122307,"product_id":8590645891,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:13-04:00","updated_at":"2016-09-23T14:14:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314146435,"product_id":8590645891,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591924099,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:15-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:16-04:00","published_at":"2015-09-23T15:47:14-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634463427,"product_id":8591924099,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:15-04:00","updated_at":"2016-09-23T15:47:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315864131,"product_id":8591924099,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:14 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:17 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590645891.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591924099.json
     body:
       encoding: US-ASCII
       string: ''
@@ -438,7 +438,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:14 GMT
+      - Fri, 23 Sep 2016 19:47:17 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -454,9 +454,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
+      - 20/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
+      - 20/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -466,9 +466,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1b0b7e87-7a0d-4452-b63e-1bc7ce3983ba?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/62bac41d-733e-4401-9896-d8d93a02371e?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 1b0b7e87-7a0d-4452-b63e-1bc7ce3983ba
+      - 62bac41d-733e-4401-9896-d8d93a02371e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -484,5 +484,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:14 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:17 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_does_not_exists_on_Shopify/creates_a_product_with_the_master_variant.yml
+++ b/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_does_not_exists_on_Shopify/creates_a_product_with_the_master_variant.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:14 GMT
+      - Fri, 23 Sep 2016 19:47:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
+      - 17/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 26/40
+      - 17/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/db0ebb29-6e3d-4f5c-a14f-99466811dc33?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/049f3185-2ba8-427b-a62f-d4809f07a7a2?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - db0ebb29-6e3d-4f5c-a14f-99466811dc33
+      - 049f3185-2ba8-427b-a62f-d4809f07a7a2
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:14 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:12 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:14.627Z","updated_at":"2016-09-23T18:14:14.682Z","published_at":"2015-09-23T18:14:14.577Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"master-sku","inventory_management":"shopify","updated_at":"2016-09-23T18:14:14.680Z","option1":"master-sku"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:47:12.422Z","updated_at":"2016-09-23T19:47:12.460Z","published_at":"2015-09-23T19:47:12.396Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"master-sku","inventory_management":"shopify","updated_at":"2016-09-23T19:47:12.458Z","option1":"master-sku"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:15 GMT
+      - Fri, 23 Sep 2016 19:47:13 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
+      - 18/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
+      - 18/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590646339
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591923779
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ddfc9552-cb4d-45bb-8ded-56ecfdf2a39e?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/534d6402-c231-40c5-b98a-a7903d5ec5f7?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - ddfc9552-cb4d-45bb-8ded-56ecfdf2a39e
+      - 534d6402-c231-40c5-b98a-a7903d5ec5f7
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590646339,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:15-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:15-04:00","published_at":"2015-09-23T14:14:14-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631124099,"product_id":8590646339,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:15-04:00","updated_at":"2016-09-23T14:14:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314147139,"product_id":8590646339,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923779,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:12-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:13-04:00","published_at":"2015-09-23T15:47:12-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634462787,"product_id":8591923779,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:13-04:00","updated_at":"2016-09-23T15:47:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863683,"product_id":8591923779,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:15 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:13 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590646339.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923779.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:15 GMT
+      - Fri, 23 Sep 2016 19:47:13 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +177,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
+      - 17/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
+      - 17/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +187,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/bbef1e54-822a-469e-87ba-276d8e4d17f5?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/d0bfa7ac-ce48-4e5f-ba98-98e7d3ae00ee?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - bbef1e54-822a-469e-87ba-276d8e4d17f5
+      - d0bfa7ac-ce48-4e5f-ba98-98e7d3ae00ee
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +203,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590646339,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:15-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:15-04:00","published_at":"2015-09-23T14:14:14-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631124099,"product_id":8590646339,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:15-04:00","updated_at":"2016-09-23T14:14:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314147139,"product_id":8590646339,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923779,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:12-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:13-04:00","published_at":"2015-09-23T15:47:12-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634462787,"product_id":8591923779,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:13-04:00","updated_at":"2016-09-23T15:47:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863683,"product_id":8591923779,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:15 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:13 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590646339.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923779.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590646339,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:14.627Z","handle":"product-name","updated_at":"2016-09-23T18:14:14.682Z","published_at":"2015-09-23T18:14:14.577Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631124099,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:15-04:00","updated_at":"2016-09-23T14:14:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314147139,"product_id":8590646339,"name":"Title","position":1,"values":["master-sku"]}],"images":[{"variant_ids":["28631124099"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591923779,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:47:12.422Z","handle":"product-name","updated_at":"2016-09-23T19:47:12.460Z","published_at":"2015-09-23T19:47:12.396Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634462787,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:13-04:00","updated_at":"2016-09-23T15:47:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863683,"product_id":8591923779,"name":"Title","position":1,"values":["master-sku"]}],"images":[{"variant_ids":["28634462787"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +233,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:16 GMT
+      - Fri, 23 Sep 2016 19:47:14 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +249,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
+      - 18/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
+      - 18/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +259,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590646339
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591923779
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/dc55c37b-6037-445c-b23c-4681aabb24aa?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b1deae3d-3d86-40dc-be05-19cddbfffd95?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - dc55c37b-6037-445c-b23c-4681aabb24aa
+      - b1deae3d-3d86-40dc-be05-19cddbfffd95
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +277,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590646339,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:15-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:15-04:00","published_at":"2015-09-23T14:14:14-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631124099,"product_id":8590646339,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:15-04:00","updated_at":"2016-09-23T14:14:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314147139,"product_id":8590646339,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923779,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:12-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:13-04:00","published_at":"2015-09-23T15:47:12-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634462787,"product_id":8591923779,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:13-04:00","updated_at":"2016-09-23T15:47:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863683,"product_id":8591923779,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:16 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:14 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590646339.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923779.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,7 +304,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:16 GMT
+      - Fri, 23 Sep 2016 19:47:14 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -320,9 +320,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
+      - 18/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 27/40
+      - 18/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -330,9 +330,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/3e0244aa-abdc-4837-a51d-7c96bf65ce23?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/995ec681-ef32-4f95-806e-345658bae0a9?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 3e0244aa-abdc-4837-a51d-7c96bf65ce23
+      - 995ec681-ef32-4f95-806e-345658bae0a9
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -346,13 +346,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590646339,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:15-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:15-04:00","published_at":"2015-09-23T14:14:14-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631124099,"product_id":8590646339,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T14:14:15-04:00","updated_at":"2016-09-23T14:14:15-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314147139,"product_id":8590646339,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923779,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:12-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:13-04:00","published_at":"2015-09-23T15:47:12-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634462787,"product_id":8591923779,"title":"master-sku","price":"19.99","sku":"master-sku","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"master-sku","option2":null,"option3":null,"created_at":"2016-09-23T15:47:13-04:00","updated_at":"2016-09-23T15:47:13-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863683,"product_id":8591923779,"name":"Title","position":1,"values":["master-sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:16 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:14 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590646339.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923779.json
     body:
       encoding: US-ASCII
       string: ''
@@ -373,7 +373,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:16 GMT
+      - Fri, 23 Sep 2016 19:47:14 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -389,9 +389,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 28/40
+      - 18/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 28/40
+      - 18/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -401,9 +401,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/dc4e6ec1-f921-4f43-b50d-85a92b847bfb?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/f26dd8b9-82cd-40f8-8c1e-54138ce3f1b9?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - dc4e6ec1-f921-4f43-b50d-85a92b847bfb
+      - f26dd8b9-82cd-40f8-8c1e-54138ce3f1b9
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -419,5 +419,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:17 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:14 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_existed_on_Shopify_but_was_deleted/creates_a_new_product.yml
+++ b/spec/cassettes/Update_a_Spree_Product_to_Shopify/when_the_product_existed_on_Shopify_but_was_deleted/creates_a_new_product.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:08 GMT
+      - Fri, 23 Sep 2016 19:47:08 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 19/40
+      - 13/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 19/40
+      - 13/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/a1467c99-3af3-460d-9fc1-401063f21ea9?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8eea06b2-dd35-49bd-9c4d-c10fc80c89b0?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - a1467c99-3af3-460d-9fc1-401063f21ea9
+      - 8eea06b2-dd35-49bd-9c4d-c10fc80c89b0
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,7 +64,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:08 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:08 GMT
 - request:
     method: get
     uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
@@ -88,7 +88,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:08 GMT
+      - Fri, 23 Sep 2016 19:47:08 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -104,9 +104,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 20/40
+      - 14/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 20/40
+      - 14/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -114,9 +114,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/71b65de3-61a6-451e-8927-819792f75904?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8c85d50e-7d42-41a6-a31c-d9f73dd83a1c?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 71b65de3-61a6-451e-8927-819792f75904
+      - 8c85d50e-7d42-41a6-a31c-d9f73dd83a1c
       X-Dc:
       - ash
       X-Download-Options:
@@ -129,15 +129,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:08 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:08 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:08.044Z","updated_at":"2016-09-23T18:14:08.070Z","published_at":"2015-09-23T18:14:08.016Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-9","inventory_management":"shopify","updated_at":"2016-09-23T18:14:08.065Z","option1":"SKU-9"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:47:07.816Z","updated_at":"2016-09-23T19:47:07.843Z","published_at":"2015-09-23T19:47:07.791Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-16","inventory_management":"shopify","updated_at":"2016-09-23T19:47:07.837Z","option1":"SKU-16"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -157,7 +157,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:08 GMT
+      - Fri, 23 Sep 2016 19:47:08 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -171,9 +171,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 15/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 15/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -181,11 +181,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590644163
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591923267
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/7a522c35-fb56-4522-a190-a81caf93e92b?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/4878a4cd-c9f9-4553-a941-a446cf856eab?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 7a522c35-fb56-4522-a190-a81caf93e92b
+      - 4878a4cd-c9f9-4553-a941-a446cf856eab
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -199,13 +199,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590644163,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:08-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:08-04:00","published_at":"2015-09-23T14:14:08-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631117379,"product_id":8590644163,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:08-04:00","updated_at":"2016-09-23T14:14:08-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314144131,"product_id":8590644163,"name":"Title","position":1,"values":["SKU-9"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923267,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:08-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:08-04:00","published_at":"2015-09-23T15:47:07-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460419,"product_id":8591923267,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:08-04:00","updated_at":"2016-09-23T15:47:08-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862915,"product_id":8591923267,"name":"Title","position":1,"values":["SKU-16"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:09 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:08 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644163.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923267.json
     body:
       encoding: US-ASCII
       string: ''
@@ -226,7 +226,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:09 GMT
+      - Fri, 23 Sep 2016 19:47:08 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -242,9 +242,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 14/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 14/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -252,9 +252,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/eef7e7a0-8b98-4c75-9a8d-822f4e8fffdb?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/1b50b01e-43dc-49a2-9135-251682a6b3f0?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - eef7e7a0-8b98-4c75-9a8d-822f4e8fffdb
+      - 1b50b01e-43dc-49a2-9135-251682a6b3f0
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -268,17 +268,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590644163,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:08-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:08-04:00","published_at":"2015-09-23T14:14:08-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631117379,"product_id":8590644163,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:08-04:00","updated_at":"2016-09-23T14:14:08-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314144131,"product_id":8590644163,"name":"Title","position":1,"values":["SKU-9"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923267,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:08-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:08-04:00","published_at":"2015-09-23T15:47:07-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460419,"product_id":8591923267,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:08-04:00","updated_at":"2016-09-23T15:47:08-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862915,"product_id":8591923267,"name":"Title","position":1,"values":["SKU-16"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:09 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:08 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644163.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923267.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590644163,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:08.044Z","handle":"product-name","updated_at":"2016-09-23T18:14:08.070Z","published_at":"2015-09-23T18:14:08.016Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631117379,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:08-04:00","updated_at":"2016-09-23T14:14:08-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314144131,"product_id":8590644163,"name":"Title","position":1,"values":["SKU-9"]}],"images":[{"variant_ids":["28631117379"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591923267,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:47:07.816Z","handle":"product-name","updated_at":"2016-09-23T19:47:07.843Z","published_at":"2015-09-23T19:47:07.791Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460419,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:08-04:00","updated_at":"2016-09-23T15:47:08-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862915,"product_id":8591923267,"name":"Title","position":1,"values":["SKU-16"]}],"images":[{"variant_ids":["28634460419"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -298,7 +298,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:09 GMT
+      - Fri, 23 Sep 2016 19:47:09 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -314,9 +314,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 15/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 15/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -324,11 +324,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590644163
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591923267
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/8c0b2fea-4072-4e55-8c23-5bb61c2b4c8c?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/fee5b485-9670-45b5-ab73-ca1d3343a380?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 8c0b2fea-4072-4e55-8c23-5bb61c2b4c8c
+      - fee5b485-9670-45b5-ab73-ca1d3343a380
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -342,13 +342,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590644163,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:08-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:09-04:00","published_at":"2015-09-23T14:14:08-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631117379,"product_id":8590644163,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:08-04:00","updated_at":"2016-09-23T14:14:08-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314144131,"product_id":8590644163,"name":"Title","position":1,"values":["SKU-9"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923267,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:08-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:09-04:00","published_at":"2015-09-23T15:47:07-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460419,"product_id":8591923267,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:08-04:00","updated_at":"2016-09-23T15:47:08-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315862915,"product_id":8591923267,"name":"Title","position":1,"values":["SKU-16"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:09 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:09 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644163.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923267.json
     body:
       encoding: US-ASCII
       string: ''
@@ -369,7 +369,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:10 GMT
+      - Fri, 23 Sep 2016 19:47:09 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -385,9 +385,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 15/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 15/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -397,9 +397,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d1c2c450-35e7-4008-90b1-7556096df584?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/83436feb-5930-4c1d-8043-2c5e6a347b9b?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - d1c2c450-35e7-4008-90b1-7556096df584
+      - 83436feb-5930-4c1d-8043-2c5e6a347b9b
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -415,10 +415,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:10 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:09 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644163.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923267.json
     body:
       encoding: US-ASCII
       string: ''
@@ -439,7 +439,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:10 GMT
+      - Fri, 23 Sep 2016 19:47:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -455,9 +455,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 15/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 21/40
+      - 15/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -465,9 +465,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/9df2429a-0e4a-4195-9bd6-732feb713390?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/e6356165-a319-4bf8-97b2-1c9f93501d8c?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 9df2429a-0e4a-4195-9bd6-732feb713390
+      - e6356165-a319-4bf8-97b2-1c9f93501d8c
       X-Dc:
       - ash
       X-Download-Options:
@@ -480,10 +480,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:10 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:10 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644163.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923267.json
     body:
       encoding: US-ASCII
       string: ''
@@ -504,7 +504,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:10 GMT
+      - Fri, 23 Sep 2016 19:47:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -520,9 +520,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 22/40
+      - 16/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 22/40
+      - 16/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -530,9 +530,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1e19cc53-7b11-4376-b0ca-761ac8270a9c?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/edd8c4ee-9932-408e-bb68-638b2ea3c2ef?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 1e19cc53-7b11-4376-b0ca-761ac8270a9c
+      - edd8c4ee-9932-408e-bb68-638b2ea3c2ef
       X-Dc:
       - ash
       X-Download-Options:
@@ -545,15 +545,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:10 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:10 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:14:08.044Z","updated_at":"2016-09-23T18:14:08.070Z","published_at":"2015-09-23T18:14:08.016Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-9","inventory_management":"shopify","updated_at":"2016-09-23T18:14:08.065Z","option1":"SKU-9"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:47:07.816Z","updated_at":"2016-09-23T19:47:07.843Z","published_at":"2015-09-23T19:47:07.791Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-16","inventory_management":"shopify","updated_at":"2016-09-23T19:47:07.837Z","option1":"SKU-16"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -573,7 +573,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:11 GMT
+      - Fri, 23 Sep 2016 19:47:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -587,9 +587,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 22/40
+      - 16/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 22/40
+      - 16/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -597,11 +597,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590644931
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591923523
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/da78572c-5a5f-47cd-a454-1e45af97b233?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/c2298f22-ab0e-4ec4-9685-6b86c5c75abe?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - da78572c-5a5f-47cd-a454-1e45af97b233
+      - c2298f22-ab0e-4ec4-9685-6b86c5c75abe
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -615,13 +615,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590644931,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:10-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:10-04:00","published_at":"2015-09-23T14:14:08-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631120387,"product_id":8590644931,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:10-04:00","updated_at":"2016-09-23T14:14:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314145155,"product_id":8590644931,"name":"Title","position":1,"values":["SKU-9"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923523,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:10-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:10-04:00","published_at":"2015-09-23T15:47:07-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460803,"product_id":8591923523,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:10-04:00","updated_at":"2016-09-23T15:47:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863299,"product_id":8591923523,"name":"Title","position":1,"values":["SKU-16"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:11 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:11 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644931.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923523.json
     body:
       encoding: US-ASCII
       string: ''
@@ -642,7 +642,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:11 GMT
+      - Fri, 23 Sep 2016 19:47:11 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -658,9 +658,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 22/40
+      - 15/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 22/40
+      - 15/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -668,9 +668,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e783d0ed-5411-4f35-9efa-1c9e4305996c?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/887c7d56-4af6-428b-8edb-db50f2b92de0?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - e783d0ed-5411-4f35-9efa-1c9e4305996c
+      - 887c7d56-4af6-428b-8edb-db50f2b92de0
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -684,17 +684,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590644931,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:10-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:10-04:00","published_at":"2015-09-23T14:14:08-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631120387,"product_id":8590644931,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:10-04:00","updated_at":"2016-09-23T14:14:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314145155,"product_id":8590644931,"name":"Title","position":1,"values":["SKU-9"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923523,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:10-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:10-04:00","published_at":"2015-09-23T15:47:07-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460803,"product_id":8591923523,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:10-04:00","updated_at":"2016-09-23T15:47:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863299,"product_id":8591923523,"name":"Title","position":1,"values":["SKU-16"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:11 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:11 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644931.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923523.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590644931,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:14:08.044Z","handle":"product-name","updated_at":"2016-09-23T18:14:08.070Z","published_at":"2015-09-23T18:14:08.016Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631120387,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:10-04:00","updated_at":"2016-09-23T14:14:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314145155,"product_id":8590644931,"name":"Title","position":1,"values":["SKU-9"]}],"images":[{"variant_ids":["28631120387"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591923523,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:47:07.816Z","handle":"product-name","updated_at":"2016-09-23T19:47:07.843Z","published_at":"2015-09-23T19:47:07.791Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460803,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:10-04:00","updated_at":"2016-09-23T15:47:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863299,"product_id":8591923523,"name":"Title","position":1,"values":["SKU-16"]}],"images":[{"variant_ids":["28634460803"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -714,7 +714,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:11 GMT
+      - Fri, 23 Sep 2016 19:47:11 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -730,9 +730,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 23/40
+      - 16/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 23/40
+      - 16/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -740,11 +740,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590644931
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591923523
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d9473ee3-2bb4-4fe4-bab9-0187d557eda7?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/976caebb-78fc-425c-8a29-73df48b2f008?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - d9473ee3-2bb4-4fe4-bab9-0187d557eda7
+      - 976caebb-78fc-425c-8a29-73df48b2f008
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -758,13 +758,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590644931,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:10-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:11-04:00","published_at":"2015-09-23T14:14:08-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631120387,"product_id":8590644931,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:10-04:00","updated_at":"2016-09-23T14:14:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314145155,"product_id":8590644931,"name":"Title","position":1,"values":["SKU-9"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923523,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:10-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:11-04:00","published_at":"2015-09-23T15:47:07-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460803,"product_id":8591923523,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:10-04:00","updated_at":"2016-09-23T15:47:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863299,"product_id":8591923523,"name":"Title","position":1,"values":["SKU-16"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:11 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:11 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644931.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923523.json
     body:
       encoding: US-ASCII
       string: ''
@@ -785,7 +785,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:12 GMT
+      - Fri, 23 Sep 2016 19:47:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -801,9 +801,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 23/40
+      - 16/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 23/40
+      - 16/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -811,9 +811,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/a087647d-c5cf-4ae1-92f7-c9e8c03a8bc5?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/92427047-d74e-4e12-8fa1-33720a23153b?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - a087647d-c5cf-4ae1-92f7-c9e8c03a8bc5
+      - 92427047-d74e-4e12-8fa1-33720a23153b
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -827,13 +827,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590644931,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:14:10-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:11-04:00","published_at":"2015-09-23T14:14:08-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631120387,"product_id":8590644931,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T14:14:10-04:00","updated_at":"2016-09-23T14:14:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314145155,"product_id":8590644931,"name":"Title","position":1,"values":["SKU-9"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591923523,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:47:10-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:47:11-04:00","published_at":"2015-09-23T15:47:07-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634460803,"product_id":8591923523,"title":"SKU-16","price":"19.99","sku":"SKU-16","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-16","option2":null,"option3":null,"created_at":"2016-09-23T15:47:10-04:00","updated_at":"2016-09-23T15:47:10-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315863299,"product_id":8591923523,"name":"Title","position":1,"values":["SKU-16"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:12 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:12 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590644931.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591923523.json
     body:
       encoding: US-ASCII
       string: ''
@@ -854,7 +854,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:12 GMT
+      - Fri, 23 Sep 2016 19:47:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -870,9 +870,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 23/40
+      - 17/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 23/40
+      - 17/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -882,9 +882,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/7570c91e-6967-4f9d-8435-5dfddf4158c1?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/625dfff0-ae78-4076-9868-37124118d99c?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 7570c91e-6967-4f9d-8435-5dfddf4158c1
+      - 625dfff0-ae78-4076-9868-37124118d99c
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -900,5 +900,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:12 GMT
+  recorded_at: Fri, 23 Sep 2016 19:47:12 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Variant_to_Shopify/assigns_the_variant_to_the_product.yml
+++ b/spec/cassettes/Update_a_Spree_Variant_to_Shopify/assigns_the_variant_to_the_product.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:37 GMT
+      - Fri, 23 Sep 2016 19:46:40 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/edb5ed8f-dc1e-4b39-aef3-7c1ed67d6573?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/052fe9ca-b836-48ea-90f8-0a68b3576bf2?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - edb5ed8f-dc1e-4b39-aef3-7c1ed67d6573
+      - 052fe9ca-b836-48ea-90f8-0a68b3576bf2
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:37 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:40 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:13:37.044Z","updated_at":"2016-09-23T18:13:37.233Z","published_at":"2015-09-23T18:13:36.821Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-1","inventory_management":"shopify","updated_at":"2016-09-23T18:13:37.104Z","option1":"SKU-1"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T18:13:37.219Z","option1":"susan"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:46:40.424Z","updated_at":"2016-09-23T19:46:40.518Z","published_at":"2015-09-23T19:46:40.367Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-9","inventory_management":"shopify","updated_at":"2016-09-23T19:46:40.444Z","option1":"SKU-9"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T19:46:40.508Z","option1":"susan"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:38 GMT
+      - Fri, 23 Sep 2016 19:46:41 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590635075
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591919747
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/f63642da-00c8-4aac-b759-22a756f19301?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/fa739068-2dc3-44c2-9b0f-9bcd4c9703a8?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - f63642da-00c8-4aac-b759-22a756f19301
+      - fa739068-2dc3-44c2-9b0f-9bcd4c9703a8
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590635075,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:37-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:37-04:00","published_at":"2015-09-23T14:13:36-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631091267,"product_id":8590635075,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631091331,"product_id":8590635075,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314132163,"product_id":8590635075,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591919747,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:41-04:00","published_at":"2015-09-23T15:46:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634448515,"product_id":8591919747,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634448579,"product_id":8591919747,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315858371,"product_id":8591919747,"name":"Title","position":1,"values":["SKU-9","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:38 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:41 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590635075.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591919747.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:38 GMT
+      - Fri, 23 Sep 2016 19:46:42 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +177,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 1/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +187,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/17fe3e72-c9cb-4507-ba0f-3e653d85c636?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/68d63515-0e27-4d5e-a689-91af50bc841d?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 17fe3e72-c9cb-4507-ba0f-3e653d85c636
+      - 68d63515-0e27-4d5e-a689-91af50bc841d
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +203,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590635075,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:37-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:37-04:00","published_at":"2015-09-23T14:13:36-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631091267,"product_id":8590635075,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631091331,"product_id":8590635075,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314132163,"product_id":8590635075,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591919747,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:41-04:00","published_at":"2015-09-23T15:46:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634448515,"product_id":8591919747,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634448579,"product_id":8591919747,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315858371,"product_id":8591919747,"name":"Title","position":1,"values":["SKU-9","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:38 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:42 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590635075.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591919747.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590635075,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:13:37.044Z","handle":"product-name","updated_at":"2016-09-23T18:13:37.233Z","published_at":"2015-09-23T18:13:36.821Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631091267,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631091331,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314132163,"product_id":8590635075,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[{"variant_ids":["28631091267"],"attachment":null},{"variant_ids":["28631091331"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591919747,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:46:40.424Z","handle":"product-name","updated_at":"2016-09-23T19:46:40.518Z","published_at":"2015-09-23T19:46:40.367Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634448515,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634448579,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315858371,"product_id":8591919747,"name":"Title","position":1,"values":["SKU-9","susan"]}],"images":[{"variant_ids":["28634448515"],"attachment":null},{"variant_ids":["28634448579"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +233,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:38 GMT
+      - Fri, 23 Sep 2016 19:46:42 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +249,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +259,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590635075
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591919747
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/416297b4-4509-4722-b30f-ee54a58ae876?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/9d9c0807-a790-4796-863b-f42bb3e2c33e?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 416297b4-4509-4722-b30f-ee54a58ae876
+      - 9d9c0807-a790-4796-863b-f42bb3e2c33e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +277,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590635075,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:37-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:38-04:00","published_at":"2015-09-23T14:13:36-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631091267,"product_id":8590635075,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631091331,"product_id":8590635075,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314132163,"product_id":8590635075,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591919747,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:42-04:00","published_at":"2015-09-23T15:46:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634448515,"product_id":8591919747,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634448579,"product_id":8591919747,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315858371,"product_id":8591919747,"name":"Title","position":1,"values":["SKU-9","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:38 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:42 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590635075/variants/28631091331.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591919747/variants/28634448579.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,147 +304,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:39 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/39ad382c-9378-4da3-b51b-873478c7ea4c?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
-      X-Request-Id:
-      - 39ad382c-9378-4da3-b51b-873478c7ea4c
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631091331,"product_id":8590635075,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:39 GMT
-- request:
-    method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28631091331.json
-    body:
-      encoding: UTF-8
-      string: '{"variant":{"id":28631091331,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T18:13:37.219Z","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":"0.0","weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:13:39 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-Shopid:
-      - '6779563'
-      X-Shardid:
-      - '2'
-      X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      Http-X-Shopify-Shop-Api-Call-Limit:
-      - 2/40
-      X-Stats-Userid:
-      - '0'
-      X-Stats-Apiclientid:
-      - '1413328'
-      X-Stats-Apipermissionid:
-      - '23658502'
-      Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590635075/variants/28631091331
-      X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c6d2bfc5-8a1e-40bd-8bdf-1030f5d72444?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
-      X-Request-Id:
-      - c6d2bfc5-8a1e-40bd-8bdf-1030f5d72444
-      P3p:
-      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
-      X-Dc:
-      - ash
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      X-Content-Type-Options:
-      - nosniff
-      - nosniff
-    body:
-      encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631091331,"product_id":8590635075,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
-    http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:39 GMT
-- request:
-    method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590635075.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
-      Accept:
-      - application/json
-      User-Agent:
-      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 23 Sep 2016 18:13:39 GMT
+      - Fri, 23 Sep 2016 19:46:42 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -470,9 +330,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/074fdffb-5a8a-4c78-85cc-63cd1fde02ee?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/7005d074-746f-4ec4-a829-0ff9b71b8585?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - 074fdffb-5a8a-4c78-85cc-63cd1fde02ee
+      - 7005d074-746f-4ec4-a829-0ff9b71b8585
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -486,13 +346,84 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590635075,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:37-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:39-04:00","published_at":"2015-09-23T14:13:36-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631091267,"product_id":8590635075,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631091331,"product_id":8590635075,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314132163,"product_id":8590635075,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
+      string: '{"variant":{"id":28634448579,"product_id":8591919747,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:39 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:43 GMT
+- request:
+    method: put
+    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28634448579.json
+    body:
+      encoding: UTF-8
+      string: '{"variant":{"id":28634448579,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T19:46:40.508Z","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":"0.0","weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+    headers:
+      Authorization:
+      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 23 Sep 2016 19:46:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '6779563'
+      X-Shardid:
+      - '2'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 2/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 2/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1413328'
+      X-Stats-Apipermissionid:
+      - '23658502'
+      Location:
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591919747/variants/28634448579
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report/28dc303f-6b5e-44ff-8739-5c4b0077d847?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      X-Request-Id:
+      - 28dc303f-6b5e-44ff-8739-5c4b0077d847
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - ash
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+    body:
+      encoding: ASCII-8BIT
+      string: '{"variant":{"id":28634448579,"product_id":8591919747,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+    http_version: 
+  recorded_at: Fri, 23 Sep 2016 19:46:43 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590635075.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591919747.json
     body:
       encoding: US-ASCII
       string: ''
@@ -513,7 +444,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:39 GMT
+      - Fri, 23 Sep 2016 19:46:44 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -529,9 +460,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 4/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 4/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -539,9 +470,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/b51fb8c9-76b9-4ed1-b3c3-d22f53d5f5ab?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/02ba60af-0855-4dcc-91fc-1bc8fa6f9941?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - b51fb8c9-76b9-4ed1-b3c3-d22f53d5f5ab
+      - 02ba60af-0855-4dcc-91fc-1bc8fa6f9941
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -555,13 +486,82 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590635075,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:37-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:39-04:00","published_at":"2015-09-23T14:13:36-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631091267,"product_id":8590635075,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631091331,"product_id":8590635075,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:37-04:00","updated_at":"2016-09-23T14:13:37-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314132163,"product_id":8590635075,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591919747,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:43-04:00","published_at":"2015-09-23T15:46:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634448515,"product_id":8591919747,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634448579,"product_id":8591919747,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315858371,"product_id":8591919747,"name":"Title","position":1,"values":["SKU-9","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:39 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:44 GMT
+- request:
+    method: get
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591919747.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 23 Sep 2016 19:46:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '6779563'
+      X-Shardid:
+      - '2'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 3/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 3/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1413328'
+      X-Stats-Apipermissionid:
+      - '23658502'
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report/9327b178-73ec-4996-bf0e-a1d30415198b?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      X-Request-Id:
+      - 9327b178-73ec-4996-bf0e-a1d30415198b
+      P3p:
+      - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
+      X-Dc:
+      - ash
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+    body:
+      encoding: ASCII-8BIT
+      string: '{"product":{"id":8591919747,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:43-04:00","published_at":"2015-09-23T15:46:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634448515,"product_id":8591919747,"title":"SKU-9","price":"19.99","sku":"SKU-9","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-9","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634448579,"product_id":8591919747,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:41-04:00","updated_at":"2016-09-23T15:46:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315858371,"product_id":8591919747,"name":"Title","position":1,"values":["SKU-9","susan"]}],"images":[],"image":null}}'
+    http_version: 
+  recorded_at: Fri, 23 Sep 2016 19:46:44 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590635075.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591919747.json
     body:
       encoding: US-ASCII
       string: ''
@@ -582,7 +582,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:40 GMT
+      - Fri, 23 Sep 2016 19:46:44 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -598,9 +598,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 4/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 4/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -610,9 +610,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/9c5fbe58-f9d4-4cef-b71a-2e21b19eb849?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/efd26443-c43a-4e59-8652-ba62c74bb28f?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 9c5fbe58-f9d4-4cef-b71a-2e21b19eb849
+      - efd26443-c43a-4e59-8652-ba62c74bb28f
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -628,5 +628,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:40 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:44 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Variant_to_Shopify/creates_a_new_variant.yml
+++ b/spec/cassettes/Update_a_Spree_Variant_to_Shopify/creates_a_new_variant.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:40 GMT
+      - Fri, 23 Sep 2016 19:46:44 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 3/40
+      - 4/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 3/40
+      - 4/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/346374fc-f90c-4d5f-befa-1100d71ed0eb?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/9bd3b16d-06fe-454e-b18c-9b7760d34f0c?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 346374fc-f90c-4d5f-befa-1100d71ed0eb
+      - 9bd3b16d-06fe-454e-b18c-9b7760d34f0c
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:40 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:44 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:13:40.563Z","updated_at":"2016-09-23T18:13:40.681Z","published_at":"2015-09-23T18:13:40.530Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-2","inventory_management":"shopify","updated_at":"2016-09-23T18:13:40.590Z","option1":"SKU-2"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T18:13:40.665Z","option1":"susan"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:46:44.655Z","updated_at":"2016-09-23T19:46:44.721Z","published_at":"2015-09-23T19:46:44.624Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-10","inventory_management":"shopify","updated_at":"2016-09-23T19:46:44.671Z","option1":"SKU-10"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T19:46:44.714Z","option1":"susan"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:41 GMT
+      - Fri, 23 Sep 2016 19:46:45 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590636035
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591920451
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c23cc300-7dcd-468a-aedd-1e0068957366?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/e4b09169-fe65-4592-a8cb-b2d3b49fb269?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - c23cc300-7dcd-468a-aedd-1e0068957366
+      - e4b09169-fe65-4592-a8cb-b2d3b49fb269
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590636035,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:41-04:00","published_at":"2015-09-23T14:13:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631092867,"product_id":8590636035,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631092931,"product_id":8590636035,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314133379,"product_id":8590636035,"name":"Title","position":1,"values":["SKU-2","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591920451,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:45-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:45-04:00","published_at":"2015-09-23T15:46:44-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634450115,"product_id":8591920451,"title":"SKU-10","price":"19.99","sku":"SKU-10","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-10","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634450179,"product_id":8591920451,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315859331,"product_id":8591920451,"name":"Title","position":1,"values":["SKU-10","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:41 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:45 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636035.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591920451.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:41 GMT
+      - Fri, 23 Sep 2016 19:46:45 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -187,9 +187,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/3a5ae6e1-c64c-4d01-b960-6f38eec22691?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/4f51ba49-16f3-4493-bab3-b5a8d222534e?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 3a5ae6e1-c64c-4d01-b960-6f38eec22691
+      - 4f51ba49-16f3-4493-bab3-b5a8d222534e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +203,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590636035,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:41-04:00","published_at":"2015-09-23T14:13:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631092867,"product_id":8590636035,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631092931,"product_id":8590636035,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314133379,"product_id":8590636035,"name":"Title","position":1,"values":["SKU-2","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591920451,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:45-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:45-04:00","published_at":"2015-09-23T15:46:44-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634450115,"product_id":8591920451,"title":"SKU-10","price":"19.99","sku":"SKU-10","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-10","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634450179,"product_id":8591920451,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315859331,"product_id":8591920451,"name":"Title","position":1,"values":["SKU-10","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:41 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:45 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636035.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591920451.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590636035,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:13:40.563Z","handle":"product-name","updated_at":"2016-09-23T18:13:40.681Z","published_at":"2015-09-23T18:13:40.530Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631092867,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631092931,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314133379,"product_id":8590636035,"name":"Title","position":1,"values":["SKU-2","susan"]}],"images":[{"variant_ids":["28631092867"],"attachment":null},{"variant_ids":["28631092931"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591920451,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:46:44.655Z","handle":"product-name","updated_at":"2016-09-23T19:46:44.721Z","published_at":"2015-09-23T19:46:44.624Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634450115,"title":"SKU-10","price":"19.99","sku":"SKU-10","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-10","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634450179,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315859331,"product_id":8591920451,"name":"Title","position":1,"values":["SKU-10","susan"]}],"images":[{"variant_ids":["28634450115"],"attachment":null},{"variant_ids":["28634450179"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +233,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:42 GMT
+      - Fri, 23 Sep 2016 19:46:46 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +249,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 4/40
+      - 5/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 4/40
+      - 5/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +259,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590636035
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591920451
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/04647d84-00af-4f54-b16f-d2b4d75b1641?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/3df00f62-b6fb-4423-935b-80bf05dd7258?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 04647d84-00af-4f54-b16f-d2b4d75b1641
+      - 3df00f62-b6fb-4423-935b-80bf05dd7258
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +277,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590636035,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:41-04:00","published_at":"2015-09-23T14:13:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631092867,"product_id":8590636035,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631092931,"product_id":8590636035,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314133379,"product_id":8590636035,"name":"Title","position":1,"values":["SKU-2","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591920451,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:45-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:45-04:00","published_at":"2015-09-23T15:46:44-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634450115,"product_id":8591920451,"title":"SKU-10","price":"19.99","sku":"SKU-10","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-10","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634450179,"product_id":8591920451,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315859331,"product_id":8591920451,"name":"Title","position":1,"values":["SKU-10","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:42 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:46 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636035/variants/28631092931.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591920451/variants/28634450179.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,7 +304,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:42 GMT
+      - Fri, 23 Sep 2016 19:46:46 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -320,9 +320,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 4/40
+      - 5/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 4/40
+      - 5/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -330,9 +330,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/fd334a37-9a96-4b82-bf8a-069f242120ec?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8a8cff4c-81ed-4bec-875a-799d096016fd?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - fd334a37-9a96-4b82-bf8a-069f242120ec
+      - 8a8cff4c-81ed-4bec-875a-799d096016fd
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -346,15 +346,15 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631092931,"product_id":8590636035,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634450179,"product_id":8591920451,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:42 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:46 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28631092931.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28634450179.json
     body:
       encoding: UTF-8
-      string: '{"variant":{"id":28631092931,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T18:13:40.665Z","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":"0.0","weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634450179,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T19:46:44.714Z","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":"0.0","weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -374,7 +374,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:42 GMT
+      - Fri, 23 Sep 2016 19:46:46 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -400,11 +400,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590636035/variants/28631092931
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591920451/variants/28634450179
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1e4dcc29-5356-45a0-aac1-5b74dde0d966?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/c81fcb9f-0685-42d7-bf67-7e7939b8fc24?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - 1e4dcc29-5356-45a0-aac1-5b74dde0d966
+      - c81fcb9f-0685-42d7-bf67-7e7939b8fc24
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -418,12 +418,12 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631092931,"product_id":8590636035,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634450179,"product_id":8591920451,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:42 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:46 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636035.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591920451.json
     body:
       encoding: US-ASCII
       string: ''
@@ -444,7 +444,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:42 GMT
+      - Fri, 23 Sep 2016 19:46:46 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -460,9 +460,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 5/40
+      - 6/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 5/40
+      - 6/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -470,9 +470,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/75fc75b3-dfdf-4661-b886-931a85380eaa?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/cdb81e59-8e14-4a62-99e3-a5239ecf8264?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 75fc75b3-dfdf-4661-b886-931a85380eaa
+      - cdb81e59-8e14-4a62-99e3-a5239ecf8264
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -486,13 +486,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590636035,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:41-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:42-04:00","published_at":"2015-09-23T14:13:40-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631092867,"product_id":8590636035,"title":"SKU-2","price":"19.99","sku":"SKU-2","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-2","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631092931,"product_id":8590636035,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:41-04:00","updated_at":"2016-09-23T14:13:41-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314133379,"product_id":8590636035,"name":"Title","position":1,"values":["SKU-2","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591920451,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:45-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:46-04:00","published_at":"2015-09-23T15:46:44-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634450115,"product_id":8591920451,"title":"SKU-10","price":"19.99","sku":"SKU-10","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-10","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634450179,"product_id":8591920451,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:45-04:00","updated_at":"2016-09-23T15:46:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315859331,"product_id":8591920451,"name":"Title","position":1,"values":["SKU-10","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:42 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:46 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636035.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591920451.json
     body:
       encoding: US-ASCII
       string: ''
@@ -513,7 +513,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:43 GMT
+      - Fri, 23 Sep 2016 19:46:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -529,9 +529,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 6/40
+      - 4/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 6/40
+      - 4/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -541,9 +541,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/de383d9f-f48d-4720-ad9b-35122c3b8b50?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/430fd2bb-2e42-4508-b545-0cb44d1406e6?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - de383d9f-f48d-4720-ad9b-35122c3b8b50
+      - 430fd2bb-2e42-4508-b545-0cb44d1406e6
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -559,5 +559,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:43 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Variant_to_Shopify/when_the_variant_already_exists_on_Shopify/does_not_create_a_new_variant.yml
+++ b/spec/cassettes/Update_a_Spree_Variant_to_Shopify/when_the_variant_already_exists_on_Shopify/does_not_create_a_new_variant.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:49 GMT
+      - Fri, 23 Sep 2016 19:46:51 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/663a337c-ca56-4985-85ba-2755ede32d09?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/855a7d34-24b4-467d-ab02-dd9a24ea323d?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 663a337c-ca56-4985-85ba-2755ede32d09
+      - 855a7d34-24b4-467d-ab02-dd9a24ea323d
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:49 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:51 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:13:49.417Z","updated_at":"2016-09-23T18:13:49.523Z","published_at":"2015-09-23T18:13:49.372Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-5","inventory_management":"shopify","updated_at":"2016-09-23T18:13:49.433Z","option1":"SKU-5"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T18:13:49.509Z","option1":"susan"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:46:51.469Z","updated_at":"2016-09-23T19:46:51.539Z","published_at":"2015-09-23T19:46:51.425Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-12","inventory_management":"shopify","updated_at":"2016-09-23T19:46:51.486Z","option1":"SKU-12"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T19:46:51.528Z","option1":"susan"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:50 GMT
+      - Fri, 23 Sep 2016 19:46:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590638595
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921475
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/cd19fea6-ae6b-49db-b7f1-d6fcc9b4e49a?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/a570dffd-9ade-4156-9b76-ac1bb634209d?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - cd19fea6-ae6b-49db-b7f1-d6fcc9b4e49a
+      - a570dffd-9ade-4156-9b76-ac1bb634209d
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590638595,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:50-04:00","published_at":"2015-09-23T14:13:49-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631098755,"product_id":8590638595,"title":"SKU-5","price":"19.99","sku":"SKU-5","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-5","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631098819,"product_id":8590638595,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314136899,"product_id":8590638595,"name":"Title","position":1,"values":["SKU-5","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921475,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:52-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:52-04:00","published_at":"2015-09-23T15:46:51-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634454659,"product_id":8591921475,"title":"SKU-12","price":"19.99","sku":"SKU-12","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-12","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634454723,"product_id":8591921475,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860739,"product_id":8591921475,"name":"Title","position":1,"values":["SKU-12","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:50 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:52 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590638595.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921475.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:50 GMT
+      - Fri, 23 Sep 2016 19:46:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +177,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +187,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e7978c15-2a40-4197-afae-60f3e76f3278?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/beb0c276-2702-4aed-9bd0-c67e36cc5879?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - e7978c15-2a40-4197-afae-60f3e76f3278
+      - beb0c276-2702-4aed-9bd0-c67e36cc5879
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +203,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590638595,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:50-04:00","published_at":"2015-09-23T14:13:49-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631098755,"product_id":8590638595,"title":"SKU-5","price":"19.99","sku":"SKU-5","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-5","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631098819,"product_id":8590638595,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314136899,"product_id":8590638595,"name":"Title","position":1,"values":["SKU-5","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921475,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:52-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:52-04:00","published_at":"2015-09-23T15:46:51-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634454659,"product_id":8591921475,"title":"SKU-12","price":"19.99","sku":"SKU-12","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-12","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634454723,"product_id":8591921475,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860739,"product_id":8591921475,"name":"Title","position":1,"values":["SKU-12","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:50 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:52 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590638595.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921475.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590638595,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:13:49.417Z","handle":"product-name","updated_at":"2016-09-23T18:13:49.523Z","published_at":"2015-09-23T18:13:49.372Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631098755,"title":"SKU-5","price":"19.99","sku":"SKU-5","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-5","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631098819,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314136899,"product_id":8590638595,"name":"Title","position":1,"values":["SKU-5","susan"]}],"images":[{"variant_ids":["28631098755"],"attachment":null},{"variant_ids":["28631098819"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591921475,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:46:51.469Z","handle":"product-name","updated_at":"2016-09-23T19:46:51.539Z","published_at":"2015-09-23T19:46:51.425Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634454659,"title":"SKU-12","price":"19.99","sku":"SKU-12","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-12","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634454723,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860739,"product_id":8591921475,"name":"Title","position":1,"values":["SKU-12","susan"]}],"images":[{"variant_ids":["28634454659"],"attachment":null},{"variant_ids":["28634454723"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +233,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:51 GMT
+      - Fri, 23 Sep 2016 19:46:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +249,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +259,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590638595
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921475
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/395035cc-2e98-4366-9c3c-28a7680b3514?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/3e08c202-ece8-44ac-9b0b-9a622a333563?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 395035cc-2e98-4366-9c3c-28a7680b3514
+      - 3e08c202-ece8-44ac-9b0b-9a622a333563
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +277,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590638595,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:51-04:00","published_at":"2015-09-23T14:13:49-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631098755,"product_id":8590638595,"title":"SKU-5","price":"19.99","sku":"SKU-5","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-5","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631098819,"product_id":8590638595,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314136899,"product_id":8590638595,"name":"Title","position":1,"values":["SKU-5","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921475,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:52-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:53-04:00","published_at":"2015-09-23T15:46:51-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634454659,"product_id":8591921475,"title":"SKU-12","price":"19.99","sku":"SKU-12","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-12","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634454723,"product_id":8591921475,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860739,"product_id":8591921475,"name":"Title","position":1,"values":["SKU-12","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:51 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:53 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590638595.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921475.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,7 +304,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:51 GMT
+      - Fri, 23 Sep 2016 19:46:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -320,9 +320,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 6/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 6/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -330,9 +330,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/5d948f33-4f24-4320-b653-79debb2f8858?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/ecdd1eba-4473-4d1b-b1ba-7a9d3ca68b25?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 5d948f33-4f24-4320-b653-79debb2f8858
+      - ecdd1eba-4473-4d1b-b1ba-7a9d3ca68b25
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -346,13 +346,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590638595,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:51-04:00","published_at":"2015-09-23T14:13:49-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631098755,"product_id":8590638595,"title":"SKU-5","price":"19.99","sku":"SKU-5","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-5","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631098819,"product_id":8590638595,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314136899,"product_id":8590638595,"name":"Title","position":1,"values":["SKU-5","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921475,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:52-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:53-04:00","published_at":"2015-09-23T15:46:51-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634454659,"product_id":8591921475,"title":"SKU-12","price":"19.99","sku":"SKU-12","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-12","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634454723,"product_id":8591921475,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860739,"product_id":8591921475,"name":"Title","position":1,"values":["SKU-12","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:51 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:53 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590638595/variants/28631098819.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921475/variants/28634454723.json
     body:
       encoding: US-ASCII
       string: ''
@@ -373,7 +373,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:52 GMT
+      - Fri, 23 Sep 2016 19:46:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -389,9 +389,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 7/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 7/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -399,9 +399,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/6adf4eb1-f802-4ad1-9f30-f4d0597ecddf?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/32e82844-7f34-4012-9b4f-04b0d646ae7e?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - 6adf4eb1-f802-4ad1-9f30-f4d0597ecddf
+      - 32e82844-7f34-4012-9b4f-04b0d646ae7e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -415,15 +415,15 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631098819,"product_id":8590638595,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634454723,"product_id":8591921475,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:52 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:53 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28631098819.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28634454723.json
     body:
       encoding: UTF-8
-      string: '{"variant":{"id":28631098819,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T18:13:49.509Z","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":"0.0","weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634454723,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T19:46:51.528Z","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":"0.0","weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -443,7 +443,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:52 GMT
+      - Fri, 23 Sep 2016 19:46:54 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -459,9 +459,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 7/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 7/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -469,11 +469,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590638595/variants/28631098819
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921475/variants/28634454723
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/cf789a2f-787b-4fa2-9d9f-21abeea76d1b?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/9d91a5d0-0529-47ba-9198-b7109cf71421?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - cf789a2f-787b-4fa2-9d9f-21abeea76d1b
+      - 9d91a5d0-0529-47ba-9198-b7109cf71421
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -487,12 +487,12 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631098819,"product_id":8590638595,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634454723,"product_id":8591921475,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:52 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:54 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590638595.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921475.json
     body:
       encoding: US-ASCII
       string: ''
@@ -513,7 +513,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:52 GMT
+      - Fri, 23 Sep 2016 19:46:54 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -529,9 +529,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 8/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 8/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -539,9 +539,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/aff9520f-fc02-428a-a3f4-22f80117054b?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/2e6c6918-7b6f-4719-8a84-0366a7fb7d39?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - aff9520f-fc02-428a-a3f4-22f80117054b
+      - 2e6c6918-7b6f-4719-8a84-0366a7fb7d39
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -555,13 +555,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590638595,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:52-04:00","published_at":"2015-09-23T14:13:49-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631098755,"product_id":8590638595,"title":"SKU-5","price":"19.99","sku":"SKU-5","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-5","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631098819,"product_id":8590638595,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314136899,"product_id":8590638595,"name":"Title","position":1,"values":["SKU-5","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921475,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:52-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:54-04:00","published_at":"2015-09-23T15:46:51-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634454659,"product_id":8591921475,"title":"SKU-12","price":"19.99","sku":"SKU-12","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-12","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634454723,"product_id":8591921475,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860739,"product_id":8591921475,"name":"Title","position":1,"values":["SKU-12","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:52 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:54 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590638595.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921475.json
     body:
       encoding: US-ASCII
       string: ''
@@ -582,7 +582,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:52 GMT
+      - Fri, 23 Sep 2016 19:46:54 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -598,9 +598,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 8/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 8/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -608,9 +608,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/9291a37b-c4af-419d-8b70-21cf0fd08d57?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/d6da0465-da0b-4205-b2bc-8e7c4960b234?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 9291a37b-c4af-419d-8b70-21cf0fd08d57
+      - d6da0465-da0b-4205-b2bc-8e7c4960b234
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -624,13 +624,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590638595,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:52-04:00","published_at":"2015-09-23T14:13:49-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631098755,"product_id":8590638595,"title":"SKU-5","price":"19.99","sku":"SKU-5","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-5","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631098819,"product_id":8590638595,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:49-04:00","updated_at":"2016-09-23T14:13:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314136899,"product_id":8590638595,"name":"Title","position":1,"values":["SKU-5","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921475,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:52-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:54-04:00","published_at":"2015-09-23T15:46:51-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634454659,"product_id":8591921475,"title":"SKU-12","price":"19.99","sku":"SKU-12","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-12","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634454723,"product_id":8591921475,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:52-04:00","updated_at":"2016-09-23T15:46:52-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860739,"product_id":8591921475,"name":"Title","position":1,"values":["SKU-12","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:52 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:54 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590638595.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921475.json
     body:
       encoding: US-ASCII
       string: ''
@@ -651,7 +651,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:53 GMT
+      - Fri, 23 Sep 2016 19:46:54 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -667,9 +667,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 9/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 14/40
+      - 9/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -679,9 +679,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/8d4eae1a-82ba-40a5-9d51-51b24de9154f?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/524f5c06-6e13-4dd8-9404-9339bd81f69b?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 8d4eae1a-82ba-40a5-9d51-51b24de9154f
+      - 524f5c06-6e13-4dd8-9404-9339bd81f69b
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -697,5 +697,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:53 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Variant_to_Shopify/when_the_variant_already_exists_on_Shopify/updates_the_existing_variant.yml
+++ b/spec/cassettes/Update_a_Spree_Variant_to_Shopify/when_the_variant_already_exists_on_Shopify/updates_the_existing_variant.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:46 GMT
+      - Fri, 23 Sep 2016 19:46:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 3/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 3/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1a57c3fe-3159-481c-b988-3755538865f8?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/67de95b1-e5be-4fd2-85d4-e6367f993a4f?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 1a57c3fe-3159-481c-b988-3755538865f8
+      - 67de95b1-e5be-4fd2-85d4-e6367f993a4f
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:46 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:49 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:13:46.391Z","updated_at":"2016-09-23T18:13:46.468Z","published_at":"2015-09-23T18:13:46.362Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-4","inventory_management":"shopify","updated_at":"2016-09-23T18:13:46.405Z","option1":"SKU-4"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T18:13:46.459Z","option1":"susan"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:46:48.884Z","updated_at":"2016-09-23T19:46:48.958Z","published_at":"2015-09-23T19:46:48.860Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-11","inventory_management":"shopify","updated_at":"2016-09-23T19:46:48.901Z","option1":"SKU-11"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T19:46:48.951Z","option1":"susan"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:47 GMT
+      - Fri, 23 Sep 2016 19:46:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 4/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 4/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590637827
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921091
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e3dfa1d1-c182-47f5-82e2-1aee18d66a80?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/c4db3965-c182-40d6-ad50-2d9edd585ae6?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - e3dfa1d1-c182-47f5-82e2-1aee18d66a80
+      - c4db3965-c182-40d6-ad50-2d9edd585ae6
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590637827,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:46-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:47-04:00","published_at":"2015-09-23T14:13:46-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631097219,"product_id":8590637827,"title":"SKU-4","price":"19.99","sku":"SKU-4","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-4","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631097283,"product_id":8590637827,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314135875,"product_id":8590637827,"name":"Title","position":1,"values":["SKU-4","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921091,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:49-04:00","published_at":"2015-09-23T15:46:48-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634453699,"product_id":8591921091,"title":"SKU-11","price":"19.99","sku":"SKU-11","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-11","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634453763,"product_id":8591921091,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860291,"product_id":8591921091,"name":"Title","position":1,"values":["SKU-11","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:47 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:49 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590637827.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921091.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:47 GMT
+      - Fri, 23 Sep 2016 19:46:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +177,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 4/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 4/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +187,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/eb2a00dd-8b2f-4f3b-8f15-63d9e85e4d82?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/7ef252b7-2c77-4a6b-a834-dfa32a858c50?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - eb2a00dd-8b2f-4f3b-8f15-63d9e85e4d82
+      - 7ef252b7-2c77-4a6b-a834-dfa32a858c50
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +203,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590637827,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:46-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:47-04:00","published_at":"2015-09-23T14:13:46-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631097219,"product_id":8590637827,"title":"SKU-4","price":"19.99","sku":"SKU-4","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-4","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631097283,"product_id":8590637827,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314135875,"product_id":8590637827,"name":"Title","position":1,"values":["SKU-4","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921091,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:49-04:00","published_at":"2015-09-23T15:46:48-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634453699,"product_id":8591921091,"title":"SKU-11","price":"19.99","sku":"SKU-11","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-11","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634453763,"product_id":8591921091,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860291,"product_id":8591921091,"name":"Title","position":1,"values":["SKU-11","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:47 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:49 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590637827.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921091.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590637827,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:13:46.391Z","handle":"product-name","updated_at":"2016-09-23T18:13:46.468Z","published_at":"2015-09-23T18:13:46.362Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631097219,"title":"SKU-4","price":"19.99","sku":"SKU-4","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-4","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631097283,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314135875,"product_id":8590637827,"name":"Title","position":1,"values":["SKU-4","susan"]}],"images":[{"variant_ids":["28631097219"],"attachment":null},{"variant_ids":["28631097283"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591921091,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:46:48.884Z","handle":"product-name","updated_at":"2016-09-23T19:46:48.958Z","published_at":"2015-09-23T19:46:48.860Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634453699,"title":"SKU-11","price":"19.99","sku":"SKU-11","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-11","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634453763,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860291,"product_id":8591921091,"name":"Title","position":1,"values":["SKU-11","susan"]}],"images":[{"variant_ids":["28634453699"],"attachment":null},{"variant_ids":["28634453763"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +233,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:47 GMT
+      - Fri, 23 Sep 2016 19:46:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +249,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 4/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 4/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +259,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590637827
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921091
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e44e8e73-34ab-45d9-81e9-c24fa263a4d3?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/f8a2c0c5-cde2-46c0-8122-b899dfec756a?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - e44e8e73-34ab-45d9-81e9-c24fa263a4d3
+      - f8a2c0c5-cde2-46c0-8122-b899dfec756a
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +277,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590637827,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:46-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:47-04:00","published_at":"2015-09-23T14:13:46-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631097219,"product_id":8590637827,"title":"SKU-4","price":"19.99","sku":"SKU-4","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-4","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631097283,"product_id":8590637827,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314135875,"product_id":8590637827,"name":"Title","position":1,"values":["SKU-4","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921091,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:50-04:00","published_at":"2015-09-23T15:46:48-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634453699,"product_id":8591921091,"title":"SKU-11","price":"19.99","sku":"SKU-11","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-11","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634453763,"product_id":8591921091,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860291,"product_id":8591921091,"name":"Title","position":1,"values":["SKU-11","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:48 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:50 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590637827/variants/28631097283.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921091/variants/28634453763.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,7 +304,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:48 GMT
+      - Fri, 23 Sep 2016 19:46:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -320,9 +320,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 4/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 10/40
+      - 4/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -330,9 +330,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/d5504364-a7f2-4b1e-9393-b62d514c098e?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/842dff51-91f2-43e4-aefc-fce6255b2445?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - d5504364-a7f2-4b1e-9393-b62d514c098e
+      - 842dff51-91f2-43e4-aefc-fce6255b2445
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -346,15 +346,15 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631097283,"product_id":8590637827,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634453763,"product_id":8591921091,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:48 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:50 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28631097283.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28634453763.json
     body:
       encoding: UTF-8
-      string: '{"variant":{"id":28631097283,"title":"susan","price":"19.99","sku":"new_sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"new_sku","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T18:13:48.186Z","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":"0.0","weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634453763,"title":"susan","price":"19.99","sku":"new_sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"new_sku","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T19:46:50.328Z","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":"0.0","weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -374,7 +374,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:48 GMT
+      - Fri, 23 Sep 2016 19:46:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -390,9 +390,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 5/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 5/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -400,11 +400,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590637827/variants/28631097283
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921091/variants/28634453763
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/ab001fc7-609c-4080-9532-19efec172a4e?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/1d766b48-294b-429e-92c2-55650eaba9a1?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - ab001fc7-609c-4080-9532-19efec172a4e
+      - 1d766b48-294b-429e-92c2-55650eaba9a1
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -418,12 +418,12 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631097283,"product_id":8590637827,"title":"new_sku","price":"19.99","sku":"new_sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"new_sku","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634453763,"product_id":8591921091,"title":"new_sku","price":"19.99","sku":"new_sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"new_sku","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:50-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:48 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:50 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590637827.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921091.json
     body:
       encoding: US-ASCII
       string: ''
@@ -444,7 +444,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:48 GMT
+      - Fri, 23 Sep 2016 19:46:51 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -460,9 +460,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 5/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 5/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -470,9 +470,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/f5e34b3e-a136-41ae-88fd-d83696ba0bad?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/369b2357-cef4-49b6-b06c-217d08d66e86?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - f5e34b3e-a136-41ae-88fd-d83696ba0bad
+      - 369b2357-cef4-49b6-b06c-217d08d66e86
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -486,13 +486,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590637827,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:46-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:48-04:00","published_at":"2015-09-23T14:13:46-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631097219,"product_id":8590637827,"title":"SKU-4","price":"19.99","sku":"SKU-4","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-4","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:46-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631097283,"product_id":8590637827,"title":"new_sku","price":"19.99","sku":"new_sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"new_sku","option2":null,"option3":null,"created_at":"2016-09-23T14:13:46-04:00","updated_at":"2016-09-23T14:13:48-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314135875,"product_id":8590637827,"name":"Title","position":1,"values":["SKU-4","new_sku"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921091,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:49-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:50-04:00","published_at":"2015-09-23T15:46:48-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634453699,"product_id":8591921091,"title":"SKU-11","price":"19.99","sku":"SKU-11","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-11","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:49-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634453763,"product_id":8591921091,"title":"new_sku","price":"19.99","sku":"new_sku","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"new_sku","option2":null,"option3":null,"created_at":"2016-09-23T15:46:49-04:00","updated_at":"2016-09-23T15:46:50-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315860291,"product_id":8591921091,"name":"Title","position":1,"values":["SKU-11","new_sku"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:48 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:51 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590637827.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921091.json
     body:
       encoding: US-ASCII
       string: ''
@@ -513,7 +513,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:49 GMT
+      - Fri, 23 Sep 2016 19:46:51 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -529,9 +529,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 6/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -541,9 +541,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/07aa5551-4d7b-4b2d-bbf5-efbc3a1022d6?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/1c483629-4277-4ede-aa66-22bd8bd38325?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 07aa5551-4d7b-4b2d-bbf5-efbc3a1022d6
+      - 1c483629-4277-4ede-aa66-22bd8bd38325
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -559,5 +559,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:49 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:51 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_a_Spree_Variant_to_Shopify/when_the_variant_existed_on_Shopify_but_was_deleted/creates_a_new_variant.yml
+++ b/spec/cassettes/Update_a_Spree_Variant_to_Shopify/when_the_variant_existed_on_Shopify_but_was_deleted/creates_a_new_variant.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:43 GMT
+      - Fri, 23 Sep 2016 19:46:55 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +39,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 6/40
+      - 8/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 6/40
+      - 8/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +49,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/defe5ab4-dd6a-40d5-8a36-be2c419593a9?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/eb5d7a76-2c3c-4f82-970e-d65005c7afe1?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - defe5ab4-dd6a-40d5-8a36-be2c419593a9
+      - eb5d7a76-2c3c-4f82-970e-d65005c7afe1
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +64,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:43 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:55 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:13:43.313Z","updated_at":"2016-09-23T18:13:43.386Z","published_at":"2015-09-23T18:13:43.282Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-3","inventory_management":"shopify","updated_at":"2016-09-23T18:13:43.330Z","option1":"SKU-3"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T18:13:43.379Z","option1":"susan"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:46:55.359Z","updated_at":"2016-09-23T19:46:55.428Z","published_at":"2015-09-23T19:46:55.322Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-13","inventory_management":"shopify","updated_at":"2016-09-23T19:46:55.379Z","option1":"SKU-13"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T19:46:55.421Z","option1":"susan"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +92,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:44 GMT
+      - Fri, 23 Sep 2016 19:46:56 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +106,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 7/40
+      - 8/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 7/40
+      - 8/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +116,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590636803
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921859
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/748aca50-3274-4ddb-bc56-08f7cd259833?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b6705d07-34b7-44d7-9560-2a505d797313?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 748aca50-3274-4ddb-bc56-08f7cd259833
+      - b6705d07-34b7-44d7-9560-2a505d797313
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +134,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590636803,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:43-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:43-04:00","published_at":"2015-09-23T14:13:43-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631094851,"product_id":8590636803,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631094915,"product_id":8590636803,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314134403,"product_id":8590636803,"name":"Title","position":1,"values":["SKU-3","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921859,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:56-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:56-04:00","published_at":"2015-09-23T15:46:55-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634455555,"product_id":8591921859,"title":"SKU-13","price":"19.99","sku":"SKU-13","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-13","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634455619,"product_id":8591921859,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861123,"product_id":8591921859,"name":"Title","position":1,"values":["SKU-13","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:44 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:56 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636803.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921859.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:44 GMT
+      - Fri, 23 Sep 2016 19:46:57 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +177,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 6/40
+      - 7/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 6/40
+      - 7/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +187,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/1c8ccf70-0ca4-4ee4-9074-89d94fbd6392?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/1d45d045-dfc2-466d-bedb-9ca3aa1bf2c7?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 1c8ccf70-0ca4-4ee4-9074-89d94fbd6392
+      - 1d45d045-dfc2-466d-bedb-9ca3aa1bf2c7
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +203,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590636803,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:43-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:43-04:00","published_at":"2015-09-23T14:13:43-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631094851,"product_id":8590636803,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631094915,"product_id":8590636803,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314134403,"product_id":8590636803,"name":"Title","position":1,"values":["SKU-3","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921859,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:56-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:56-04:00","published_at":"2015-09-23T15:46:55-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634455555,"product_id":8591921859,"title":"SKU-13","price":"19.99","sku":"SKU-13","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-13","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634455619,"product_id":8591921859,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861123,"product_id":8591921859,"name":"Title","position":1,"values":["SKU-13","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:44 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:57 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636803.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921859.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590636803,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:13:43.313Z","handle":"product-name","updated_at":"2016-09-23T18:13:43.386Z","published_at":"2015-09-23T18:13:43.282Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631094851,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631094915,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314134403,"product_id":8590636803,"name":"Title","position":1,"values":["SKU-3","susan"]}],"images":[{"variant_ids":["28631094851"],"attachment":null},{"variant_ids":["28631094915"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8591921859,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:46:55.359Z","handle":"product-name","updated_at":"2016-09-23T19:46:55.428Z","published_at":"2015-09-23T19:46:55.322Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634455555,"title":"SKU-13","price":"19.99","sku":"SKU-13","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-13","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634455619,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861123,"product_id":8591921859,"name":"Title","position":1,"values":["SKU-13","susan"]}],"images":[{"variant_ids":["28634455555"],"attachment":null},{"variant_ids":["28634455619"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +233,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:44 GMT
+      - Fri, 23 Sep 2016 19:46:57 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +249,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 7/40
+      - 8/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 7/40
+      - 8/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +259,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590636803
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921859
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c06a81cd-30bc-46b4-88fc-589288e33108?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/b94c429e-d9cf-4917-a857-c15b18807a99?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - c06a81cd-30bc-46b4-88fc-589288e33108
+      - b94c429e-d9cf-4917-a857-c15b18807a99
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +277,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590636803,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:43-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:44-04:00","published_at":"2015-09-23T14:13:43-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631094851,"product_id":8590636803,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631094915,"product_id":8590636803,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314134403,"product_id":8590636803,"name":"Title","position":1,"values":["SKU-3","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921859,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:56-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:57-04:00","published_at":"2015-09-23T15:46:55-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634455555,"product_id":8591921859,"title":"SKU-13","price":"19.99","sku":"SKU-13","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-13","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634455619,"product_id":8591921859,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861123,"product_id":8591921859,"name":"Title","position":1,"values":["SKU-13","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:44 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:57 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28631094915.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/variants/28634455619.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,7 +304,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:44 GMT
+      - Fri, 23 Sep 2016 19:46:57 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -320,9 +320,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 7/40
+      - 8/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 7/40
+      - 8/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -330,9 +330,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/8966b080-3c88-414c-80ca-61097276ee9b?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/fb9bbe0d-b852-45a3-bd6c-4d9a4fd1b587?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - 8966b080-3c88-414c-80ca-61097276ee9b
+      - fb9bbe0d-b852-45a3-bd6c-4d9a4fd1b587
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -346,12 +346,12 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631094915,"product_id":8590636803,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634455619,"product_id":8591921859,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:44 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:57 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636803/variants/28631094915.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921859/variants/28634455619.json
     body:
       encoding: US-ASCII
       string: ''
@@ -372,7 +372,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:45 GMT
+      - Fri, 23 Sep 2016 19:46:58 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -400,9 +400,9 @@ http_interactions:
       Location:
       - "/admin/products"
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/a027e5f7-9603-4ea2-9564-ff3e10eb219e?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/5ef476a7-23e7-4fde-942e-a34a5aca5b10?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - a027e5f7-9603-4ea2-9564-ff3e10eb219e
+      - 5ef476a7-23e7-4fde-942e-a34a5aca5b10
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -418,10 +418,10 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:45 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:58 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636803/variants/28631094915.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921859/variants/28634455619.json
     body:
       encoding: US-ASCII
       string: ''
@@ -442,7 +442,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:45 GMT
+      - Fri, 23 Sep 2016 19:46:58 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -468,9 +468,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/76fa8a4e-7cdb-411f-87dd-d76d4c20481f?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/a9e9584d-12b3-4e0b-9728-177ab91deff3?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - 76fa8a4e-7cdb-411f-87dd-d76d4c20481f
+      - a9e9584d-12b3-4e0b-9728-177ab91deff3
       X-Dc:
       - ash
       X-Download-Options:
@@ -483,13 +483,13 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:45 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:58 GMT
 - request:
     method: post
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636803/variants.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921859/variants.json
     body:
       encoding: UTF-8
-      string: '{"variant":{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T18:13:43.379Z","option1":"susan"}}'
+      string: '{"variant":{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T19:46:55.421Z","option1":"susan"}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -509,7 +509,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:45 GMT
+      - Fri, 23 Sep 2016 19:46:58 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -533,11 +533,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590636803/variants
+      - https://glossier-pop-staging.myshopify.com/admin/products/8591921859/variants
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/18747969-9bdb-4c2c-acd3-00df3f73a773?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8e8966a7-4fb2-4d70-9a01-e6175e1c0d1b?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - 18747969-9bdb-4c2c-acd3-00df3f73a773
+      - 8e8966a7-4fb2-4d70-9a01-e6175e1c0d1b
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -551,12 +551,12 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"variant":{"id":28631095683,"product_id":8590636803,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:45-04:00","updated_at":"2016-09-23T14:13:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634456067,"product_id":8591921859,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:58-04:00","updated_at":"2016-09-23T15:46:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:45 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:58 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636803.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921859.json
     body:
       encoding: US-ASCII
       string: ''
@@ -577,7 +577,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:45 GMT
+      - Fri, 23 Sep 2016 19:46:59 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -603,9 +603,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c1b13ebd-93bc-4ee6-ab72-6861d1633626?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/8fe58d8a-3f95-4f95-bf53-63a7c5f23fe0?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - c1b13ebd-93bc-4ee6-ab72-6861d1633626
+      - 8fe58d8a-3f95-4f95-bf53-63a7c5f23fe0
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -619,13 +619,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590636803,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:43-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:45-04:00","published_at":"2015-09-23T14:13:43-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631094851,"product_id":8590636803,"title":"SKU-3","price":"19.99","sku":"SKU-3","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-3","option2":null,"option3":null,"created_at":"2016-09-23T14:13:43-04:00","updated_at":"2016-09-23T14:13:43-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631095683,"product_id":8590636803,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:45-04:00","updated_at":"2016-09-23T14:13:45-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314134403,"product_id":8590636803,"name":"Title","position":1,"values":["SKU-3","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8591921859,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:46:56-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:46:58-04:00","published_at":"2015-09-23T15:46:55-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634455555,"product_id":8591921859,"title":"SKU-13","price":"19.99","sku":"SKU-13","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-13","option2":null,"option3":null,"created_at":"2016-09-23T15:46:56-04:00","updated_at":"2016-09-23T15:46:56-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634456067,"product_id":8591921859,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:46:58-04:00","updated_at":"2016-09-23T15:46:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10315861123,"product_id":8591921859,"name":"Title","position":1,"values":["SKU-13","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:45 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:59 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590636803.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8591921859.json
     body:
       encoding: US-ASCII
       string: ''
@@ -646,7 +646,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:46 GMT
+      - Fri, 23 Sep 2016 19:46:59 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -674,9 +674,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/f93f5c22-580e-4ba0-b8d7-e0b0e5faf114?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/51bd139d-3f94-45da-901c-83bd07194e06?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - f93f5c22-580e-4ba0-b8d7-e0b0e5faf114
+      - 51bd139d-3f94-45da-901c-83bd07194e06
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -692,5 +692,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:46 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Update_the_Shopify_Variant_quantity_with_the_Spree_Variant_quantity/saves_the_variant_new_inventory_quantity.yml
+++ b/spec/cassettes/Update_the_Shopify_Variant_quantity_with_the_Spree_Variant_quantity/saves_the_variant_new_inventory_quantity.yml
@@ -2,6 +2,138 @@
 http_interactions:
 - request:
     method: get
+    uri: https://glossier-pop-staging.myshopify.com/admin/variants/.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
+      Accept:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 23 Sep 2016 19:46:36 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '6779563'
+      X-Shardid:
+      - '2'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 1/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1413328'
+      X-Stats-Apipermissionid:
+      - '23658502'
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report/0b231aec-e762-4624-bf4e-95a629ab6bf9?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      X-Request-Id:
+      - 0b231aec-e762-4624-bf4e-95a629ab6bf9
+      X-Dc:
+      - ash
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":"Not Found"}'
+    http_version: 
+  recorded_at: Fri, 23 Sep 2016 19:46:36 GMT
+- request:
+    method: post
+    uri: https://glossier-pop-staging.myshopify.com/admin/variants.json
+    body:
+      encoding: UTF-8
+      string: '{"variant":{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T19:46:36.017Z","option1":"susan"}}'
+    headers:
+      Authorization:
+      - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ShopifyAPI/4.3.2 ActiveResource/4.1.0 Ruby/2.3.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 23 Sep 2016 19:46:36 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-Shopid:
+      - '6779563'
+      X-Shardid:
+      - '2'
+      X-Shopify-Shop-Api-Call-Limit:
+      - 2/40
+      Http-X-Shopify-Shop-Api-Call-Limit:
+      - 2/40
+      X-Stats-Userid:
+      - '0'
+      X-Stats-Apiclientid:
+      - '1413328'
+      X-Stats-Apipermissionid:
+      - '23658502'
+      X-Xss-Protection:
+      - 1; mode=block; report=/xss-report/c7b81a62-ff6c-4bd4-a55a-d48e2871ab06?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      X-Request-Id:
+      - c7b81a62-ff6c-4bd4-a55a-d48e2871ab06
+      X-Dc:
+      - ash
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Content-Type-Options:
+      - nosniff
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors":"Invalid Product"}'
+    http_version: 
+  recorded_at: Fri, 23 Sep 2016 19:46:36 GMT
+- request:
+    method: get
     uri: https://glossier-pop-staging.myshopify.com/admin/products/.json
     body:
       encoding: US-ASCII
@@ -23,7 +155,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:58 GMT
+      - Fri, 23 Sep 2016 19:46:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -39,9 +171,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 11/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -49,9 +181,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/2ea4bdfe-d719-4b96-84e0-9632330b9579?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/71d075ca-15ed-4d56-afa2-99117f409547?source%5Baction%5D=error_404&source%5Bcontroller%5D=admin%2Ferrors&source%5Bsection%5D=admin
       X-Request-Id:
-      - 2ea4bdfe-d719-4b96-84e0-9632330b9579
+      - 71d075ca-15ed-4d56-afa2-99117f409547
       X-Dc:
       - ash
       X-Download-Options:
@@ -64,15 +196,15 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"errors":"Not Found"}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:58 GMT
+  recorded_at: Fri, 23 Sep 2016 19:46:37 GMT
 - request:
     method: post
     uri: https://glossier-pop-staging.myshopify.com/admin/products.json
     body:
       encoding: UTF-8
       string: '{"product":{"title":"Product Name","body_html":"\u003cp\u003eAs seen
-        on TV!\u003c/p\u003e","created_at":"2016-09-23T18:13:58.105Z","updated_at":"2016-09-23T18:13:58.198Z","published_at":"2015-09-23T18:13:58.061Z","vendor":"Default
-        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-6","inventory_management":"shopify","updated_at":"2016-09-23T18:13:58.121Z","option1":"SKU-6"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T18:13:58.188Z","option1":"susan"}]}}'
+        on TV!\u003c/p\u003e","created_at":"2016-09-23T19:58:54.432Z","updated_at":"2016-09-23T19:58:54.582Z","published_at":"2015-09-23T19:58:53.617Z","vendor":"Default
+        Vendor","handle":"product-name","variants":[{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"SKU-1","inventory_management":"shopify","updated_at":"2016-09-23T19:58:54.499Z","option1":"SKU-1"},{"weight":"0.0","weight_unit":"oz","price":"19.99","sku":"susan","inventory_management":"shopify","updated_at":"2016-09-23T19:58:54.573Z","option1":"susan"}]}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -92,7 +224,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:58 GMT
+      - Fri, 23 Sep 2016 19:58:55 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -106,9 +238,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 1/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 1/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -116,11 +248,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590641155
+      - https://glossier-pop-staging.myshopify.com/admin/products/8592093379
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/7a12856d-f434-4ad0-82ea-4d8da52d955c?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/86edf64e-77db-4fa4-a949-c414a5bc10db?source%5Baction%5D=create&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 7a12856d-f434-4ad0-82ea-4d8da52d955c
+      - 86edf64e-77db-4fa4-a949-c414a5bc10db
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -134,13 +266,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590641155,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:58-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:58-04:00","published_at":"2015-09-23T14:13:58-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631105667,"product_id":8590641155,"title":"SKU-6","price":"19.99","sku":"SKU-6","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-6","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631105731,"product_id":8590641155,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314140227,"product_id":8590641155,"name":"Title","position":1,"values":["SKU-6","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592093379,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:58:55-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:58:55-04:00","published_at":"2015-09-23T15:58:53-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634787651,"product_id":8592093379,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634787715,"product_id":8592093379,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316080259,"product_id":8592093379,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:58 GMT
+  recorded_at: Fri, 23 Sep 2016 19:58:55 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590641155.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592093379.json
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +293,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:59 GMT
+      - Fri, 23 Sep 2016 19:58:56 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -177,9 +309,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 1/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 1/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -187,9 +319,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e6c9447d-6f53-4a3e-9d0c-8de72125b8ce?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/d7f098d5-237c-42b5-a176-eb5fea07565e?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - e6c9447d-6f53-4a3e-9d0c-8de72125b8ce
+      - d7f098d5-237c-42b5-a176-eb5fea07565e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -203,17 +335,17 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590641155,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:58-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:58-04:00","published_at":"2015-09-23T14:13:58-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631105667,"product_id":8590641155,"title":"SKU-6","price":"19.99","sku":"SKU-6","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-6","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631105731,"product_id":8590641155,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314140227,"product_id":8590641155,"name":"Title","position":1,"values":["SKU-6","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592093379,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:58:55-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:58:55-04:00","published_at":"2015-09-23T15:58:53-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634787651,"product_id":8592093379,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634787715,"product_id":8592093379,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316080259,"product_id":8592093379,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:59 GMT
+  recorded_at: Fri, 23 Sep 2016 19:58:56 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590641155.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592093379.json
     body:
       encoding: UTF-8
-      string: '{"product":{"id":8590641155,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T18:13:58.105Z","handle":"product-name","updated_at":"2016-09-23T18:13:58.198Z","published_at":"2015-09-23T18:13:58.061Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631105667,"title":"SKU-6","price":"19.99","sku":"SKU-6","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-6","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631105731,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314140227,"product_id":8590641155,"name":"Title","position":1,"values":["SKU-6","susan"]}],"images":[{"variant_ids":["28631105667"],"attachment":null},{"variant_ids":["28631105731"],"attachment":null}],"image":null}}'
+      string: '{"product":{"id":8592093379,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T19:58:54.432Z","handle":"product-name","updated_at":"2016-09-23T19:58:54.582Z","published_at":"2015-09-23T19:58:53.617Z","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634787651,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634787715,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316080259,"product_id":8592093379,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[{"variant_ids":["28634787651"],"attachment":null},{"variant_ids":["28634787715"],"attachment":null}],"image":null}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -233,7 +365,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:59 GMT
+      - Fri, 23 Sep 2016 19:58:56 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -249,9 +381,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 1/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 12/40
+      - 1/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -259,11 +391,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590641155
+      - https://glossier-pop-staging.myshopify.com/admin/products/8592093379
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/e455552d-b83d-408f-978a-6c378fbdbe1c?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/29101fae-43df-457a-af50-68a7d05ca2f0?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - e455552d-b83d-408f-978a-6c378fbdbe1c
+      - 29101fae-43df-457a-af50-68a7d05ca2f0
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -277,13 +409,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590641155,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:58-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:13:59-04:00","published_at":"2015-09-23T14:13:58-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631105667,"product_id":8590641155,"title":"SKU-6","price":"19.99","sku":"SKU-6","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-6","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631105731,"product_id":8590641155,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10314140227,"product_id":8590641155,"name":"Title","position":1,"values":["SKU-6","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592093379,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:58:55-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:58:56-04:00","published_at":"2015-09-23T15:58:53-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634787651,"product_id":8592093379,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634787715,"product_id":8592093379,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}],"options":[{"id":10316080259,"product_id":8592093379,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:59 GMT
+  recorded_at: Fri, 23 Sep 2016 19:58:57 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590641155/variants/28631105731.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592093379/variants/28634787715.json
     body:
       encoding: US-ASCII
       string: ''
@@ -304,7 +436,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:13:59 GMT
+      - Fri, 23 Sep 2016 19:58:57 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -320,9 +452,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 1/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 1/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -330,9 +462,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/6583234e-90bc-4c20-82f3-7f262b2e0622?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/7d232c22-aca0-49e8-b027-1f549599955e?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - 6583234e-90bc-4c20-82f3-7f262b2e0622
+      - 7d232c22-aca0-49e8-b027-1f549599955e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -346,15 +478,15 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631105731,"product_id":8590641155,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634787715,"product_id":8592093379,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:13:59 GMT
+  recorded_at: Fri, 23 Sep 2016 19:58:57 GMT
 - request:
     method: put
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590641155/variants/28631105731.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592093379/variants/28634787715.json
     body:
       encoding: UTF-8
-      string: '{"variant":{"id":28631105731,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":10,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634787715,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":10,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true}}'
     headers:
       Authorization:
       - Basic MWI3ZjYzYmYyNDg4MzFjN2FlMmJlYWNmOWJjMzBiYmI6YjFjOTE1NTE1ZDA4ZTIwMzc5MzBhODQ0Zjc0MzY2MTA=
@@ -374,7 +506,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:00 GMT
+      - Fri, 23 Sep 2016 19:58:57 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -390,9 +522,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -400,11 +532,11 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       Location:
-      - https://glossier-pop-staging.myshopify.com/admin/products/8590641155/variants/28631105731
+      - https://glossier-pop-staging.myshopify.com/admin/products/8592093379/variants/28634787715
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/bff12cb9-2792-45ae-9c68-16f32314535a?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/aab3f1e0-f837-420e-a79f-3bb45e61474e?source%5Baction%5D=update&source%5Bcontroller%5D=admin%2Fproduct_variants&source%5Bsection%5D=admin
       X-Request-Id:
-      - bff12cb9-2792-45ae-9c68-16f32314535a
+      - aab3f1e0-f837-420e-a79f-3bb45e61474e
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -418,12 +550,12 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"variant":{"id":28631105731,"product_id":8590641155,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:14:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":10,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":10,"requires_shipping":true}}'
+      string: '{"variant":{"id":28634787715,"product_id":8592093379,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:57-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":10,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":10,"requires_shipping":true}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:00 GMT
+  recorded_at: Fri, 23 Sep 2016 19:58:58 GMT
 - request:
     method: get
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590641155.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592093379.json
     body:
       encoding: US-ASCII
       string: ''
@@ -444,7 +576,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:00 GMT
+      - Fri, 23 Sep 2016 19:58:58 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -460,9 +592,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 1/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 1/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -470,9 +602,9 @@ http_interactions:
       X-Stats-Apipermissionid:
       - '23658502'
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/c50bac2e-047a-4cd3-a5d4-37696ce939fe?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/82129a04-f1ce-4e78-8eb3-10b698c88af4?source%5Baction%5D=show&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - c50bac2e-047a-4cd3-a5d4-37696ce939fe
+      - 82129a04-f1ce-4e78-8eb3-10b698c88af4
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -486,13 +618,13 @@ http_interactions:
       - nosniff
     body:
       encoding: ASCII-8BIT
-      string: '{"product":{"id":8590641155,"title":"Product Name","body_html":"\u003cp\u003eAs
-        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T14:13:58-04:00","handle":"product-name-12","updated_at":"2016-09-23T14:14:00-04:00","published_at":"2015-09-23T14:13:58-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28631105667,"product_id":8590641155,"title":"SKU-6","price":"19.99","sku":"SKU-6","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-6","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:13:58-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28631105731,"product_id":8590641155,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T14:13:58-04:00","updated_at":"2016-09-23T14:14:00-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":10,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":10,"requires_shipping":true}],"options":[{"id":10314140227,"product_id":8590641155,"name":"Title","position":1,"values":["SKU-6","susan"]}],"images":[],"image":null}}'
+      string: '{"product":{"id":8592093379,"title":"Product Name","body_html":"\u003cp\u003eAs
+        seen on TV!\u003c\/p\u003e","vendor":"Default Vendor","product_type":"","created_at":"2016-09-23T15:58:55-04:00","handle":"product-name-12","updated_at":"2016-09-23T15:58:57-04:00","published_at":"2015-09-23T15:58:53-04:00","template_suffix":null,"published_scope":"global","tags":"","variants":[{"id":28634787651,"product_id":8592093379,"title":"SKU-1","price":"19.99","sku":"SKU-1","position":1,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"SKU-1","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:55-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":1,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":1,"requires_shipping":true},{"id":28634787715,"product_id":8592093379,"title":"susan","price":"19.99","sku":"susan","position":2,"grams":0,"inventory_policy":"deny","compare_at_price":null,"fulfillment_service":"manual","inventory_management":"shopify","option1":"susan","option2":null,"option3":null,"created_at":"2016-09-23T15:58:55-04:00","updated_at":"2016-09-23T15:58:57-04:00","taxable":true,"barcode":null,"image_id":null,"inventory_quantity":10,"weight":0.0,"weight_unit":"oz","old_inventory_quantity":10,"requires_shipping":true}],"options":[{"id":10316080259,"product_id":8592093379,"name":"Title","position":1,"values":["SKU-1","susan"]}],"images":[],"image":null}}'
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:00 GMT
+  recorded_at: Fri, 23 Sep 2016 19:58:58 GMT
 - request:
     method: delete
-    uri: https://glossier-pop-staging.myshopify.com/admin/products/8590641155.json
+    uri: https://glossier-pop-staging.myshopify.com/admin/products/8592093379.json
     body:
       encoding: US-ASCII
       string: ''
@@ -513,7 +645,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 23 Sep 2016 18:14:01 GMT
+      - Fri, 23 Sep 2016 19:58:58 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -529,9 +661,9 @@ http_interactions:
       X-Shardid:
       - '2'
       X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 2/40
       Http-X-Shopify-Shop-Api-Call-Limit:
-      - 13/40
+      - 2/40
       X-Stats-Userid:
       - '0'
       X-Stats-Apiclientid:
@@ -541,9 +673,9 @@ http_interactions:
       Location:
       - https://glossier-pop-staging.myshopify.com/admin/products
       X-Xss-Protection:
-      - 1; mode=block; report=/xss-report/16e15651-61c2-46d4-8f84-d3460a7818c6?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
+      - 1; mode=block; report=/xss-report/efe7baae-5521-4134-8b7c-e1e7582fdd6c?source%5Baction%5D=destroy&source%5Bcontroller%5D=admin%2Fproducts&source%5Bsection%5D=admin
       X-Request-Id:
-      - 16e15651-61c2-46d4-8f84-d3460a7818c6
+      - efe7baae-5521-4134-8b7c-e1e7582fdd6c
       P3p:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
       X-Dc:
@@ -559,5 +691,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "{}"
     http_version: 
-  recorded_at: Fri, 23 Sep 2016 18:14:01 GMT
+  recorded_at: Fri, 23 Sep 2016 19:58:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 module Spree
   RSpec.describe Product do
     let(:product_exporter_instance) { double('exporter_instance', perform: true) }
+    let(:variant_updater_instance) { double('updater_instance', perform: true) }
 
     before do
       allow(Shopify::ProductExporter).to receive(:new).and_return(product_exporter_instance)
+      allow(Shopify::VariantUpdater).to receive(:new).and_return(variant_updater_instance)
     end
 
     describe 'when creating' do

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+module Spree
+  RSpec.describe Variant do
+    let(:product_exporter_instance) { double('exporter_instance', perform: true) }
+    let(:variant_updater_instance) { double('updater_instance', perform: true) }
+
+    before do
+      allow(Shopify::ProductExporter).to receive(:new).and_return(product_exporter_instance)
+      allow(Shopify::VariantUpdater).to receive(:new).and_return(variant_updater_instance)
+    end
+
+    describe 'when creating' do
+      describe 'if the disable_shopify_sync is set to true' do
+        subject { build(:variant, disable_shopify_sync: true) }
+
+        it 'does not call the create_shopify_variant method' do
+          expect(subject).not_to receive(:create_shopify_variant)
+          subject.save
+        end
+      end
+
+      describe 'a regular variant' do
+        subject { build(:variant) }
+
+        it 'calls the variant exporter' do
+          expect(variant_updater_instance).to receive(:perform)
+          subject.save
+        end
+      end
+    end
+
+    describe 'when destroying' do
+      describe 'if the disable_shopify_sync is set to true' do
+        subject { create(:variant, disable_shopify_sync: true) }
+
+        it 'does not call the destroy_shopify_variant method' do
+          expect(subject).not_to receive(:destroy_shopify_variant)
+          subject.destroy
+        end
+      end
+
+      describe 'a regular variant' do
+        describe 'without a retail variant ID' do
+          subject { create(:variant) }
+
+          it 'does not call find on the Shopify api' do
+            expect(ShopifyAPI::Variant).not_to receive(:find_by_id)
+            subject.destroy
+          end
+        end
+
+        describe 'with a retail variant ID' do
+          subject { create(:variant, pos_variant_id: '123321') }
+          let(:shopify_variant) { double('shopify_variant', destroy: true) }
+
+          describe 'when the variant is not found on Shopify' do
+            before do
+              expect(ShopifyAPI::Variant).to receive(:find_by_id).and_return(nil)
+            end
+
+            it 'does not call destroy on the variant Shopify api' do
+              expect(shopify_variant).not_to receive(:destroy)
+              subject.destroy
+            end
+          end
+
+          describe 'when the variant is found on Shopify' do
+            before do
+              expect(ShopifyAPI::Variant).to receive(:find_by_id).and_return(shopify_variant)
+            end
+
+            it 'calls destroy on the variant Shopify api' do
+              expect(shopify_variant).to receive(:destroy)
+              subject.destroy
+            end
+          end
+        end
+      end
+    end
+
+    describe 'properties' do
+      subject { build_stubbed(:variant, pos_variant_id: '8675309') }
+
+      it 'knows its retail variant ID' do
+        expect(subject.pos_variant_id).to eq '8675309'
+      end
+    end
+  end
+end

--- a/spec/requests/shopify/export_bundle_product_spec.rb
+++ b/spec/requests/shopify/export_bundle_product_spec.rb
@@ -6,7 +6,7 @@ describe 'Export a bundled Spree product with its assembly on Shopify', :vcr do
   include_context 'phase_2_bundle'
 
   let(:bundle) { create(:product, disable_shopify_sync: true) }
-  let!(:parts) { (1..3).map { |i| create(:variant, sku: "SKUS-#{i}") } }
+  let(:parts) { (1..3).map { |i| create(:variant, sku: "SKUS-#{i}", disable_shopify_sync: true) } }
   let!(:bundle_parts) { bundle.parts << parts }
 
   before do

--- a/spec/requests/shopify/export_product_spec.rb
+++ b/spec/requests/shopify/export_product_spec.rb
@@ -4,7 +4,7 @@ describe 'Export a Spree product with its variants on Shopify', :vcr do
   include_context 'shopify_exporter_helpers'
   include_context 'shopify_helpers'
 
-  let!(:spree_variant) { create(:variant, sku: 'slave-sku', product: spree_product) }
+  let!(:spree_variant) { create(:variant, sku: 'slave-sku', product: spree_product, disable_shopify_sync: true) }
   let(:spree_product) { create(:product, name: 'Product Name', disable_shopify_sync: true) }
 
   before do

--- a/spec/requests/shopify/update_stock_spec.rb
+++ b/spec/requests/shopify/update_stock_spec.rb
@@ -5,7 +5,7 @@ describe 'Update the Shopify Variant quantity with the Spree Variant quantity', 
   include_context 'shopify_helpers'
 
   let(:spree_product) { create(:product, name: 'Product Name', disable_shopify_sync: true) }
-  let!(:spree_variant) { create(:variant, product: spree_product, sku: 'susan') }
+  let!(:spree_variant) { create(:variant, product: spree_product, sku: 'susan', disable_shopify_sync: true) }
 
   before do
     export_product_and_variants!(spree_product)

--- a/spec/requests/shopify/update_variant_spec.rb
+++ b/spec/requests/shopify/update_variant_spec.rb
@@ -5,7 +5,7 @@ describe 'Update a Spree Variant to Shopify', :vcr do
   include_context 'shopify_helpers'
 
   let(:spree_product) { create(:product, name: 'Product Name', disable_shopify_sync: true) }
-  let!(:spree_variant) { create(:variant, product: spree_product, sku: 'susan') }
+  let!(:spree_variant) { create(:variant, product: spree_product, sku: 'susan', disable_shopify_sync: true) }
 
   before do
     export_product_and_variants!(spree_product)


### PR DESCRIPTION
Problematic case:

Once a Solidus gets updated, we want to trigger an after_update event
that will trigger the task that will update this product to Shopify.

When we update it on Shopify, in a certain case the product on Shopify
may have been deleted so we need to re-create it. When we re-create it,
we need to save the shopify_variant_id to the Solidus variant. And there
goes an infinite loop

This solves that.
