### PR TITLE
Better express the dependency on spree_product_asssembly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-# TODO: I feel like this should not be belonging here and
-# I feel like this should not be part of the retail gem.
-gem 'spree_product_assembly', github: 'glossier/spree-product-assembly', branch: 'solidus'

--- a/lib/spree/retail/engine.rb
+++ b/lib/spree/retail/engine.rb
@@ -1,5 +1,6 @@
 require 'solidus_core'
 require 'shopify_api'
+require 'solidus_product_assembly'
 
 module Spree
   module Retail

--- a/solidus_retail.gemspec
+++ b/solidus_retail.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'redcarpet'
   s.add_dependency 'solidus_core', ['< 1.4', '>= 1.3.0.alpha']
   s.add_dependency 'solidus_gateway', '< 1.4'
+  s.add_dependency 'solidus_product_assembly'
 
   s.add_development_dependency 'capybara', '~> 2.7'
   s.add_development_dependency 'poltergeist', '~> 1.10'

--- a/spec/requests/shopify/export_bundle_product_spec.rb
+++ b/spec/requests/shopify/export_bundle_product_spec.rb
@@ -6,7 +6,7 @@ describe 'Export a bundled Spree product with its assembly on Shopify', :vcr do
   include_context 'phase_2_bundle'
 
   let(:bundle) { create(:product) }
-  let!(:parts) { (1..3).map { |i| create(:variant, sku: "SKUS-#{i}") } }
+  let(:parts) { (1..3).map { |i| create(:variant, sku: "SKUS-#{i}") } }
   let!(:bundle_parts) { bundle.parts << parts }
 
   before do


### PR DESCRIPTION
A major problem right now is that the way we are using the assembly gem
in our fork is different of the original implementation.

Instead of a product having parts (which is the case in our fork),
variants have parts (in the original implementation). We'll have to
figure something out.

This solves https://github.com/glossier/solidus_retail/issues/37
