### PR TITLE
Adjusts Spree::Stock::Estimator Behaviour

### DIFF
--- a/app/models/spree/generate_pos_order.rb
+++ b/app/models/spree/generate_pos_order.rb
@@ -4,6 +4,8 @@ module Spree
 
     def initialize(order)
       @order = order
+
+      Spree::Config.stock.estimator_class = "::Spree::Retail::Stock::Estimator"
     end
 
     def process

--- a/app/models/spree/retail/stock/estimator.rb
+++ b/app/models/spree/retail/stock/estimator.rb
@@ -1,0 +1,9 @@
+module Spree::Retail
+  module Stock
+    class Estimator < Spree::Stock::Estimator
+      def shipping_rates(package, frontend_only = false)
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR proposes to adjust the estimator's behaviour to evaluate all shipping-methods when the order's source is a POS. The default behaviour remains, only evaluating frontend-only shipping-methods.
