### PR TITLE
Use the options_text as the variant title

### DIFF
--- a/app/converters/spree/retail/shopify/variant_converter.rb
+++ b/app/converters/spree/retail/shopify/variant_converter.rb
@@ -15,6 +15,7 @@ module Spree
             sku: variant.sku,
             inventory_management: 'shopify',
             requires_shipping: false,
+            title: variant.options_text,
             updated_at: variant.updated_at
           }.merge(variant_uniqueness_constraint).merge(variant_product_id)
         end

--- a/app/converters/spree/retail/shopify/variant_converter.rb
+++ b/app/converters/spree/retail/shopify/variant_converter.rb
@@ -15,7 +15,6 @@ module Spree
             sku: variant.sku,
             inventory_management: 'shopify',
             requires_shipping: false,
-            title: variant.options_text,
             updated_at: variant.updated_at
           }.merge(variant_uniqueness_constraint).merge(variant_product_id)
         end
@@ -24,8 +23,10 @@ module Spree
 
         attr_reader :variant, :aggregated
 
+        # NOTE: We can't manually set the title of the variant, the first
+        # option is always the title of the variant, which is really weird :(
         def variant_uniqueness_constraint
-          { option1: variant.sku }
+          { option1: variant.options_text }
         end
 
         def variant_product_id

--- a/solidus_retail.gemspec
+++ b/solidus_retail.gemspec
@@ -2,6 +2,7 @@
 $:.push File.expand_path('../lib', __FILE__)
 require 'solidus_retail/version'
 
+# rubocop:disable BlockLength
 Gem::Specification.new do |s|
   s.name        = 'solidus_retail'
   s.version     = SolidusRetail::VERSION

--- a/spec/converters/spree/retail/shopify/variant_converter_spec.rb
+++ b/spec/converters/spree/retail/shopify/variant_converter_spec.rb
@@ -52,15 +52,11 @@ module Spree::Retail::Shopify
       end
 
       it 'uses the sku has the unique constraint value' do
-        expect(subject[:option1]).to eql('boy-brow')
+        expect(subject[:option1]).to eql('smells like flowers')
       end
 
       it 'has the inventory management set to shopify' do
         expect(subject[:inventory_management]).to eql('shopify')
-      end
-
-      it 'uses the same options_text has the title' do
-        expect(subject[:title]).to eql('smells like flowers')
       end
     end
   end

--- a/spec/converters/spree/retail/shopify/variant_converter_spec.rb
+++ b/spec/converters/spree/retail/shopify/variant_converter_spec.rb
@@ -21,6 +21,7 @@ module Spree::Retail::Shopify
         build_spree_variant(weight: 10, weight_unit: 'oz',
                             price: 23.32, sku: 'boy-brow',
                             product: spree_product,
+                            options_text: 'smells like flowers',
                             updated_at: updated_at_date)
       end
 
@@ -52,6 +53,14 @@ module Spree::Retail::Shopify
 
       it 'uses the sku has the unique constraint value' do
         expect(subject[:option1]).to eql('boy-brow')
+      end
+
+      it 'has the inventory management set to shopify' do
+        expect(subject[:inventory_management]).to eql('shopify')
+      end
+
+      it 'uses the same options_text has the title' do
+        expect(subject[:title]).to eql('smells like flowers')
       end
     end
   end

--- a/spec/support/shared/spree_builders.rb
+++ b/spec/support/shared/spree_builders.rb
@@ -33,6 +33,7 @@ RSpec.shared_context 'spree_builders' do
                           weight: 10, weight_unit: 'oz',
                           price: 10.45, option_values: [],
                           pos_variant_id: '321',
+                          options_text: 'options_text',
                           updated_at: build_date_time)
 
     variant = double(:spree_variant)
@@ -46,6 +47,7 @@ RSpec.shared_context 'spree_builders' do
     allow(variant).to receive(:sku).and_return(sku)
     allow(variant).to receive(:updated_at).and_return(updated_at)
     allow(variant).to receive(:option_values).and_return(option_values)
+    allow(variant).to receive(:options_text).and_return(options_text)
 
     variant
   end


### PR DESCRIPTION
That way it's easier to recognize what each variants are. Right now we
were using the SKUs number which was not very self explanatory.

https://app.clubhouse.io/dynamomtl/story/108/as-a-pos-user-i-want-to-see-the-variant-title-instead-of-the-variant-skus
