### PR TITLE
Use the first option value presentation as the variant title

### DIFF
--- a/app/converters/spree/retail/shopify/variant_converter.rb
+++ b/app/converters/spree/retail/shopify/variant_converter.rb
@@ -24,9 +24,9 @@ module Spree
         attr_reader :variant, :aggregated
 
         # NOTE: We can't manually set the title of the variant, the first
-        # option is always the title of the variant, which is really weird :(
+        # option is always the title of the variant, which is really weird.
         def variant_uniqueness_constraint
-          { option1: variant.options_text }
+          { option1: variant_title_value }
         end
 
         def variant_product_id
@@ -41,6 +41,12 @@ module Spree
 
         def variant_product
           variant.product
+        end
+
+        def variant_title_value
+          return variant.sku unless variant.option_values.any?
+
+          variant.option_values.first.presentation
         end
       end
     end

--- a/app/converters/spree/retail/shopify/variant_converter.rb
+++ b/app/converters/spree/retail/shopify/variant_converter.rb
@@ -26,7 +26,7 @@ module Spree
         # NOTE: We can't manually set the title of the variant, the first
         # option is always the title of the variant, which is really weird.
         def variant_uniqueness_constraint
-          { option1: variant_title_value }
+          { option1: variant.title }
         end
 
         def variant_product_id
@@ -41,12 +41,6 @@ module Spree
 
         def variant_product
           variant.product
-        end
-
-        def variant_title_value
-          return variant.sku unless variant.option_values.any?
-
-          variant.option_values.first.presentation
         end
       end
     end

--- a/app/presenters/spree/retail/shopify/variant_presenter.rb
+++ b/app/presenters/spree/retail/shopify/variant_presenter.rb
@@ -9,6 +9,12 @@ module Spree
         def default_pos_image
           images.first
         end
+
+        def title
+          return sku unless option_values.any?
+
+          option_values.first.presentation
+        end
       end
     end
   end

--- a/spec/converters/spree/retail/shopify/variant_converter_spec.rb
+++ b/spec/converters/spree/retail/shopify/variant_converter_spec.rb
@@ -17,11 +17,12 @@ module Spree::Retail::Shopify
     describe '.to_hash' do
       let(:spree_product) { build_spree_product(id: 321, pos_product_id: 123) }
       let(:updated_at_date) { build_date_time(year: 2016, month: 1, day: 1, hour: 12, minute: 0, second: 0 ) }
+      let(:option_value) { build_spree_option_value(presentation: 'jam') }
       let(:spree_variant) do
         build_spree_variant(weight: 10, weight_unit: 'oz',
                             price: 23.32, sku: 'boy-brow',
                             product: spree_product,
-                            options_text: 'smells like flowers',
+                            option_values: [option_value],
                             updated_at: updated_at_date)
       end
 
@@ -51,8 +52,22 @@ module Spree::Retail::Shopify
         expect(subject[:updated_at]).to eql(updated_at_date)
       end
 
-      it 'uses the sku has the unique constraint value' do
-        expect(subject[:option1]).to eql('smells like flowers')
+      it 'uses the first presentation value has the unique constraint value' do
+        expect(subject[:option1]).to eql('jam')
+      end
+
+      describe 'when it has no option_values' do
+        let(:spree_variant) do
+          build_spree_variant(weight: 10, weight_unit: 'oz',
+                              price: 23.32, sku: 'boy-brow',
+                              product: spree_product,
+                              option_values: [],
+                              updated_at: updated_at_date)
+        end
+
+        it 'uses the sku has the unique constraint value' do
+          expect(subject[:option1]).to eql('boy-brow')
+        end
       end
 
       it 'has the inventory management set to shopify' do

--- a/spec/converters/spree/retail/shopify/variant_converter_spec.rb
+++ b/spec/converters/spree/retail/shopify/variant_converter_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module Spree::Retail::Shopify
   RSpec.describe VariantConverter do
+    include PresenterHelper
     include_context 'spree_builders'
 
     let(:spree_variant) { build_spree_variant }
@@ -25,8 +26,9 @@ module Spree::Retail::Shopify
                             option_values: [option_value],
                             updated_at: updated_at_date)
       end
+      let(:presented_variant) { present(spree_variant, :variant) }
 
-      subject { described_class.new(variant: spree_variant).to_hash }
+      subject { described_class.new(variant: presented_variant).to_hash }
 
       it 'keeps the same weight value' do
         expect(subject[:weight]).to eql(10)

--- a/spec/support/shared/spree_builders.rb
+++ b/spec/support/shared/spree_builders.rb
@@ -31,9 +31,8 @@ RSpec.shared_context 'spree_builders' do
 
   def build_spree_variant(product: nil, sku: 'sku',
                           weight: 10, weight_unit: 'oz',
-                          price: 10.45, option_values: [],
+                          price: 10.45, option_values: [build_spree_option_value],
                           pos_variant_id: '321',
-                          options_text: 'options_text',
                           updated_at: build_date_time)
 
     variant = double(:spree_variant)
@@ -47,7 +46,6 @@ RSpec.shared_context 'spree_builders' do
     allow(variant).to receive(:sku).and_return(sku)
     allow(variant).to receive(:updated_at).and_return(updated_at)
     allow(variant).to receive(:option_values).and_return(option_values)
-    allow(variant).to receive(:options_text).and_return(options_text)
 
     variant
   end


### PR DESCRIPTION
In Shopify we were representing the variant title with the following string
`price: 10$` for a gift card

Now it will only show:
`10$`
