### PR TITLE
We need to persist the capture transaction, not auth or refund

### DIFF
--- a/app/models/spree/retail/shopify/generate_pos_order.rb
+++ b/app/models/spree/retail/shopify/generate_pos_order.rb
@@ -122,7 +122,7 @@ module Spree
         def transition_order_from_payment_to_confirm!(spree_order, shopify_order)
           payment = spree_order.payments.create(payment_method: default_payment_method)
           payment.amount = spree_order.total
-          payment.response_code = shopify_order.transactions.first.id
+          payment.response_code = shopify_order.transactions.find { |t| t.kind == 'capture' }.id
           payment.save
         end
 

--- a/spec/support/data/transactions.json
+++ b/spec/support/data/transactions.json
@@ -19,6 +19,26 @@
       "receipt": {},
       "error_code": null,
       "source_name": "web"
+    },
+    {
+      "id": 179259969,
+      "order_id": 450789469,
+      "amount": "209.00",
+      "kind": "capture",
+      "gateway": "bogus",
+      "status": "success",
+      "message": null,
+      "created_at": "2005-08-05T12:59:12-04:00",
+      "test": false,
+      "authorization": "authorization-key",
+      "currency": "USD",
+      "location_id": null,
+      "user_id": null,
+      "parent_id": null,
+      "device_id": null,
+      "receipt": {},
+      "error_code": null,
+      "source_name": "web"
     }
   ]
 }


### PR DESCRIPTION
This will allow refunds to be processed correctly