### PR TITLE
Add the proper tax adjustments on refund

### DIFF
--- a/spec/importers/spree/retail/shopify/refund_importer_spec.rb
+++ b/spec/importers/spree/retail/shopify/refund_importer_spec.rb
@@ -34,6 +34,20 @@ module Spree::Retail::Shopify
           expect{ subject.perform }.to change(Spree::CustomerReturn, :count).by 1
         end
 
+        it 'adds the correct amount of taxes to the order' do
+          subject.perform
+          expect(last_order.total).to eql(13.07)
+        end
+
+        it 'adds the adjustmennts containing the taxes to the line item' do
+          subject.perform
+          line_item = last_order.line_items.first
+
+          expect(line_item.adjustments.count).to eql(2)
+          expect(line_item.adjustments[0].label).to eql('NY State Tax')
+          expect(line_item.adjustments[1].label).to eql('New York County Tax')
+        end
+
         it 'sets the order state to returned' do
           subject.perform
           expect(last_order).to be_returned

--- a/spec/support/data/refunds.json
+++ b/spec/support/data/refunds.json
@@ -18,7 +18,7 @@
       "quantity": 1,
       "price": "12.00",
       "grams": 0,
-      "sku": "ZIP100-KIT-2",
+      "sku": "SKU-1",
       "variant_title": "ZIP100-KIT-2",
       "vendor": "Glossier",
       "fulfillment_service": "manual",


### PR DESCRIPTION
It seems like that when you create a refund on Solidus, it removes all
the adjustments associated with an order.

The adjustments is what contained the taxes, so by removing the
adjustments, the order decreases prices and thus we refund the client
with a lower amount of money than they actually paid.