### PR TITLE
Add reimbursement tax calculator

### DIFF
--- a/app/models/spree/retail/reimbursement_tax_calculator.rb
+++ b/app/models/spree/retail/reimbursement_tax_calculator.rb
@@ -1,0 +1,30 @@
+module Spree
+  module Retail
+    class ReimbursementTaxCalculator
+      class << self
+        def call(reimbursement)
+          reimbursement.return_items.includes(:inventory_unit).each do |return_item|
+            set_tax!(return_item)
+          end
+        end
+
+        private
+
+        def set_tax!(return_item)
+          # The Shopify taxes are not imported has taxes in Solidus. We create
+          # an adjustment for every tax type. When we need to calculate the tax
+          # for the refund process, we need to retrieve those adjustments and
+          # count them has taxes so we can refund the proper amount to the client.
+          adjustment_amount = return_item.inventory_unit.line_item.adjustments.map(&:amount).inject(:+)
+
+          # For sakes of clarity
+          additional_tax_total = adjustment_amount
+
+          return_item.update_attributes!({
+            additional_tax_total: additional_tax_total
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/retail/shopify/reimbursement.rb
+++ b/app/models/spree/retail/shopify/reimbursement.rb
@@ -6,6 +6,7 @@ module Spree
 
         def create(customer_return)
           reimbursement = build_reimbursement_from(customer_return)
+          reimbursement.reimbursement_tax_calculator = reimbursement_tax_calculator
           reimbursement.save
           reimbursement.pos_refunded!
           reimbursement.perform!
@@ -19,6 +20,10 @@ module Spree
 
         def build_reimbursement_from(customer_return)
           Spree::Reimbursement.build_from_customer_return(customer_return)
+        end
+
+        def reimbursement_tax_calculator
+          Spree::Retail::ReimbursementTaxCalculator
         end
       end
     end

--- a/spec/importers/spree/retail/shopify/refund_importer_spec.rb
+++ b/spec/importers/spree/retail/shopify/refund_importer_spec.rb
@@ -39,6 +39,14 @@ module Spree::Retail::Shopify
           expect(last_order).to be_returned
         end
 
+        it 'matches the Shopify refund total' do
+          subject.perform
+          last_order_refund_total = last_order.reimbursements.map(&:total).inject(:+)
+          refund_transaction_total = shopify_refund.transactions.first.amount.to_f
+
+          expect(last_order_refund_total).to eql(refund_transaction_total)
+        end
+
         it 'goes through the success path' do
           expect(callback).to receive(:success_case).once
           subject.perform


### PR DESCRIPTION
The Shopify taxes are not imported has taxes in Solidus. We create
an adjustment for every tax type. When we need to calculate the tax
for the refund process, we need to retrieve those adjustments and
count them has taxes so we can refund the proper amount to the client.