### PR TITLE
Fix/additional refund bug fixing

### DIFF
--- a/app/importers/spree/retail/shopify/refund_importer.rb
+++ b/app/importers/spree/retail/shopify/refund_importer.rb
@@ -18,6 +18,7 @@ module Spree
 
           callback.success_case
         rescue => e
+          require 'pry'; binding.pry
           logger.exception_raised(e)
           callback.failure_case
         end

--- a/app/importers/spree/retail/shopify/refund_importer.rb
+++ b/app/importers/spree/retail/shopify/refund_importer.rb
@@ -18,7 +18,6 @@ module Spree
 
           callback.success_case
         rescue => e
-          require 'pry'; binding.pry
           logger.exception_raised(e)
           callback.failure_case
         end

--- a/app/models/spree/retail/calculator/returns/default_refund_amount.rb
+++ b/app/models/spree/retail/calculator/returns/default_refund_amount.rb
@@ -1,0 +1,43 @@
+require_dependency 'spree/returns_calculator'
+
+module Spree
+  module Retail
+    module Calculator
+      module Returns
+        class DefaultRefundAmount < ReturnsCalculator
+          def compute(return_item)
+            return 0.0.to_d if return_item.part_of_exchange?
+            if return_item.inventory_unit.line_item.parts.any?
+              return_item.inventory_unit.line_item.amount * percentage_of_line_item_for_bundles(return_item.inventory_unit)
+            else
+              weighted_order_adjustment_amount(return_item.inventory_unit) + weighted_line_item_amount(return_item.inventory_unit)
+            end
+          end
+
+          private
+
+          def weighted_order_adjustment_amount(inventory_unit)
+            inventory_unit.order.adjustments.eligible.non_tax.sum(:amount) * percentage_of_order_total(inventory_unit)
+          end
+
+          def weighted_line_item_amount(inventory_unit)
+            inventory_unit.line_item.discounted_amount * percentage_of_line_item(inventory_unit)
+          end
+
+          def percentage_of_order_total(inventory_unit)
+            return 0.0 if inventory_unit.order.discounted_item_amount.zero?
+            weighted_line_item_amount(inventory_unit) / inventory_unit.order.discounted_item_amount
+          end
+
+          def percentage_of_line_item(inventory_unit)
+            1 / BigDecimal.new(inventory_unit.line_item.quantity)
+          end
+
+          def percentage_of_line_item_for_bundles(inventory_unit)
+            inventory_unit.variant.price / BigDecimal.new(inventory_unit.line_item.amount)
+          end
+          end
+        end
+      end
+    end
+  end

--- a/app/models/spree/retail/calculator/returns/default_refund_amount.rb
+++ b/app/models/spree/retail/calculator/returns/default_refund_amount.rb
@@ -37,7 +37,7 @@ module Spree
           def total_price_of_inventory_unit(inventory_unit)
             prices = []
             inventory_unit.line_item.parts.each do |p|
-              variant = p.product.variants.detect(&:part?)
+              variant = p.product.variants.first
               prices << variant.price
             end
 

--- a/app/models/spree/retail/reimbursement_tax_calculator.rb
+++ b/app/models/spree/retail/reimbursement_tax_calculator.rb
@@ -15,7 +15,13 @@ module Spree
           # an adjustment for every tax type. When we need to calculate the tax
           # for the refund process, we need to retrieve those adjustments and
           # count them has taxes so we can refund the proper amount to the client.
-          adjustment_amount = return_item.inventory_unit.line_item.adjustments.map(&:amount).inject(:+)
+          line_item = return_item.inventory_unit.line_item
+          adjustment_amount = line_item.adjustments.map(&:amount).inject(:+)
+
+          # Parts man....
+          if line_item.parts.any?
+            adjustment_amount /= line_item.parts.count
+          end
 
           # For sakes of clarity
           additional_tax_total = adjustment_amount

--- a/app/models/spree/retail/shopify/return_items.rb
+++ b/app/models/spree/retail/shopify/return_items.rb
@@ -28,7 +28,8 @@ module Spree
         def create(inventory_unit)
           Spree::ReturnItem.create(
             inventory_unit: inventory_unit,
-            preferred_reimbursement_type: reimbursement_type
+            preferred_reimbursement_type: reimbursement_type,
+            refund_amount_calculator: default_refund_calculator
           ).tap(&:accept!)
         end
 
@@ -36,6 +37,10 @@ module Spree
 
         def reimbursement_type
           Spree::ReimbursementType.first
+        end
+
+        def default_refund_calculator
+          Spree::Retail::Calculator::Returns::DefaultRefundAmount
         end
 
         def variant_skus_for_bundle(item)

--- a/app/models/spree/retail/shopify/return_items.rb
+++ b/app/models/spree/retail/shopify/return_items.rb
@@ -8,7 +8,18 @@ module Spree
           return_items = []
           shopify_refund_line_items.each do |rli|
             inventory_unit = order.all_inventory_units.detect { |iu| iu.variant.pos_variant_id == rli.line_item.variant_id.to_s }
-            return_items << create(inventory_unit)
+
+            # This probably means that it's a bundled product
+            if inventory_unit.nil?
+              bundle_variants = variant_skus_for_bundle(rli.line_item)
+              inventory_units = order.all_inventory_units.select { |iu| bundle_variants.include?(iu.variant.sku) }
+
+              inventory_units.each do |iu|
+                return_items << create(iu)
+              end
+            else
+              return_items << create(inventory_unit)
+            end
           end
 
           return_items
@@ -25,6 +36,14 @@ module Spree
 
         def reimbursement_type
           Spree::ReimbursementType.first
+        end
+
+        def variant_skus_for_bundle(item)
+          variants = []
+          item.sku.split('/').drop(1).each do |v|
+            variants << v.gsub("-SET", "")
+          end
+          variants
         end
       end
     end


### PR DESCRIPTION
This custom refund calculator will take care of the bundled products.

The previous default refund calculator would use the line_item price to
calculate the return_item price. The way that bundle works, is that a
line_item contains multiple inventory units.

So if a bundle product line_item was set to 65$, each inventory unit
being returned that were part of the bundled product would be priced at
65$.

We can't simply device the number of inventory units associated with
bundled line_item because some items have more value than the others. We
try to calculate a certain ratio so the item we reimburse is fair.

Those commits take care of fixing that situation.