### PR TITLE
Namespace Updater Classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@
 
 AllCops:
   Exclude:
+    - 'bin/*'
     - 'spec/dummy/**/*'
     - 'vendor/bundle/**/*'
   TargetRubyVersion: 2.1

--- a/app/operations/spree/retail/shopify/product_operations.rb
+++ b/app/operations/spree/retail/shopify/product_operations.rb
@@ -10,9 +10,9 @@ module Spree
 
           def update(spree_product:)
             if spree_product.assembly?
-              service = BundledProductExporter.new(spree_product: spree_product)
+              service = ::Spree::Retail::Shopify::BundledProductExporter.new(spree_product: spree_product)
             else
-              service = ProductUpdater.new(spree_product: spree_product)
+              service = ::Spree::Retail::Shopify::ProductUpdater.new(spree_product: spree_product)
             end
 
             service.perform

--- a/solidus_retail.gemspec
+++ b/solidus_retail.gemspec
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 $:.push File.expand_path('../lib', __FILE__)
 require 'solidus_retail/version'
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -10,6 +10,6 @@ VCR.configure do |c|
 
   c.default_cassette_options = {
     record: ENV.key?('TRAVIS') ? :none : :new_episodes,
-    match_requests_on: [:method, :path]
+    match_requests_on: %i(method path)
   }
 end


### PR DESCRIPTION
The Retail gem has some pretty aggressive namespacing going on. Due to
this (I believe), that when updating bundled products on Shopify, the
BundledProductExporter won't be firing within the Retail namespace. This
will cause the update to fail and halt the entire request/response
lifecycle.