### PR TITLE
Set the Default Store to 1 when Creating Orders

### DIFF
--- a/app/models/spree/retail/shopify/generate_pos_order.rb
+++ b/app/models/spree/retail/shopify/generate_pos_order.rb
@@ -40,7 +40,8 @@ module Spree
         end
 
         def create_order
-          Spree::Order.new(currency: ::Spree::Config[:currency], pos: true)
+          default_store = Store.find_by(default: true)
+          Spree::Order.new(currency: ::Spree::Config[:currency], pos: true, store_id: default_store.id)
         end
 
         def add_line_items(order, pos_order)

--- a/spec/models/spree/retail/shopify/generate_pos_order/generate_pos_order_spec.rb
+++ b/spec/models/spree/retail/shopify/generate_pos_order/generate_pos_order_spec.rb
@@ -38,6 +38,11 @@ Spree.describe Spree::Retail::Shopify::GeneratePosOrder, type: :model do
       expect(last_order.line_items.first.adjustments.count).to eql(1)
     end
 
+    it 'creates an order with a store_id set to 1 by default' do
+      subject
+      expect(last_order.store_id).to eql(1)
+    end
+
     it 'ships the shipments' do
       subject
       expect(last_order.shipments).to all(be_shipped)


### PR DESCRIPTION
Some shopify orders are currently getting a store_id = 2 when imported to Glossier